### PR TITLE
Upgrade to scala-2.10.0-M5

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ By providing smaller resolution proofs that are easier and faster to check, Skep
 
 ###Usage Instructions###
 
-You must have [SBT](https://github.com/harrah/xsbt/wiki/Getting-Started-Setup) installed. 
+You must have [SBT](https://github.com/harrah/xsbt/wiki/Getting-Started-Setup) (version >= 0.13) installed. 
 Then go to Skeptik's root directory using the terminal and simply execute:
 
 ```

--- a/build.sbt
+++ b/build.sbt
@@ -4,16 +4,16 @@ organization := "at.logic"
 
 version := "0.2-SNAPSHOT"
 
-scalaVersion := "2.9.2"
+scalaVersion := "2.10.0-M5"
 
-scalacOptions ++= Seq("-unchecked", "-deprecation")
+scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature")
+
+scalacOptions in doc ++= Seq("diagrams","on")
 
 libraryDependencies ++= Seq(
-  "org.scalatest" %% "scalatest" % "1.7.2",
-//  "org.scalatest" % "scalatest_2.9.2" % "1.7.2",
-  "org.specs2" %% "specs2" % "1.10",
-//  "org.specs2" % "specs2_2.9.2" % "1.10",
-  "org.scalacheck" %% "scalacheck" % "1.9",
+  "org.scalatest" %% "scalatest" % "1.9-2.10.0-M5-B2",
+  "org.specs2" %% "specs2" % "1.11",
+  "org.scalacheck" %% "scalacheck" % "1.10.0",
   "junit" % "junit" % "4.10"
 )
 
@@ -59,18 +59,18 @@ pomExtra := (
 				<groupId>net.alchim31.maven</groupId>
 				<artifactId>scala-maven-plugin</artifactId>
 				<version>3.0.2</version>
+				<configuration>
+                	<args>
+                    	<arg>-diagrams</arg>
+                    	<arg>-implicits</arg>
+                	</args>
+                </configuration>
 				<executions>
 					<execution>
 						<goals>
 							<goal>compile</goal>
 							<goal>testCompile</goal>
 						</goals>
-						<configuration>
-							<args>
-								<arg>-make:transitive</arg>
-								<arg>-dependencyfile</arg>
-							</args>
-						</configuration>
 					</execution>
 				</executions>
 			</plugin>
@@ -82,9 +82,6 @@ pomExtra := (
 				<groupId>net.alchim31.maven</groupId>
 				<artifactId>scala-maven-plugin</artifactId>
 				<version>3.0.2</version>
-				<configuration>
-					<scalaVersion>2.9.1</scalaVersion>
-				</configuration>
 			</plugin>
 		</plugins>
 	</reporting>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0">
     <modelVersion>4.0.0</modelVersion>
     <groupId>at.logic</groupId>
-    <artifactId>skeptik_2.9.1</artifactId>
+    <artifactId>skeptik_2.10.0-M5</artifactId>
     <packaging>jar</packaging>
     <description>Skeptik</description>
     <url>http://github.com/Paradoxika/Skeptik</url>
@@ -40,18 +40,18 @@
                 <groupId>net.alchim31.maven</groupId>
                 <artifactId>scala-maven-plugin</artifactId>
                 <version>3.0.2</version>
+                <configuration>
+                    <args>
+                        <arg>-diagrams</arg>
+                        <arg>-implicits</arg>
+                    </args>
+                </configuration>
                 <executions>
                     <execution>
                         <goals>
                             <goal>compile</goal>
                             <goal>testCompile</goal>
                         </goals>
-                        <configuration>
-                            <args>
-                                <arg>-make:transitive</arg>
-                                <arg>-dependencyfile</arg>
-                            </args>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>
@@ -63,9 +63,6 @@
                 <groupId>net.alchim31.maven</groupId>
                 <artifactId>scala-maven-plugin</artifactId>
                 <version>3.0.2</version>
-                <configuration>
-                    <scalaVersion>2.9.1</scalaVersion>
-                </configuration>
             </plugin>
         </plugins>
     </reporting>
@@ -73,25 +70,25 @@
         <dependency>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-library</artifactId>
-            <version>2.9.1</version>
+            <version>2.10.0-M5</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.scalatest</groupId>
-            <artifactId>scalatest_2.9.1</artifactId>
-            <version>1.7.2</version>
+            <artifactId>scalatest_2.10.0-M5</artifactId>
+            <version>1.9-2.10.0-M5-B2</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_2.9.1</artifactId>
-            <version>1.10</version>
+            <artifactId>specs2_2.10.0-M5</artifactId>
+            <version>1.11</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.scalacheck</groupId>
-            <artifactId>scalacheck_2.9.1</artifactId>
-            <version>1.9</version>
+            <artifactId>scalacheck_2.10.0-M5</artifactId>
+            <version>1.10.0</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/src/main/scala/at/logic/skeptik/algorithm/compressor/combinedRPILU/RegularizationEvaluation.scala
+++ b/src/main/scala/at/logic/skeptik/algorithm/compressor/combinedRPILU/RegularizationEvaluation.scala
@@ -155,14 +155,14 @@ extends RegularizationEvaluation {
 trait AddEval extends RegularizationEvaluation {
 // Assumes all the possible regularizations will happend.
   def addMap(ma: Map[E,Float], mb: Map[E,Float]):Map[E,Float] =
-    ma.keys.foldLeft(mb) { (acc,k) => acc + (k -> (ma(k) + mb.getOrElse(k,0..toFloat))) }
+    ma.keys.foldLeft(mb) { (acc,k) => acc + (k -> (ma(k) + mb.getOrElse(k,0.0.toFloat))) }
   def evaluateDerivation(proof: SequentProof, nodeCollection: ProofNodeCollection[SequentProof], aux: E,
                          leftInfo: RegularizationInformation, rightInfo:RegularizationInformation):RegularizationInformation = {
     val (left,right) = (proof.premises(0), proof.premises(1))
     def evalRegularization(node: SequentProof, information: RegularizationInformation) =
-      if (fakeSize(nodeCollection.childrenOf(node)) == 1) information.nodeSize + 1..toFloat else 1..toFloat
+      if (fakeSize(nodeCollection.childrenOf(node)) == 1) information.nodeSize + 1.0.toFloat else 1.0.toFloat
     RegularizationInformation(
-      evalRegularization(left, leftInfo) + evalRegularization(right,rightInfo) - 1..toFloat,
+      evalRegularization(left, leftInfo) + evalRegularization(right,rightInfo) - 1.0.toFloat,
       addMap(leftInfo.leftMap,  rightInfo.leftMap)  + (aux -> evalRegularization(left, leftInfo)),
       addMap(leftInfo.rightMap, rightInfo.rightMap) + (aux -> evalRegularization(right,rightInfo))
     )
@@ -178,7 +178,7 @@ trait MinEval extends RegularizationEvaluation {
   def evaluateDerivation(proof: SequentProof, nodeCollection: ProofNodeCollection[SequentProof], aux: E,
                          leftInfo: RegularizationInformation, rightInfo:RegularizationInformation):RegularizationInformation = {
     RegularizationInformation(
-      leftInfo.nodeSize + rightInfo.nodeSize - 1..toFloat,
+      leftInfo.nodeSize + rightInfo.nodeSize - 1.0.toFloat,
       minMap(leftInfo.leftMap,  rightInfo.leftMap)  + (aux -> leftInfo.nodeSize),
       minMap(leftInfo.rightMap, rightInfo.rightMap) + (aux -> rightInfo.nodeSize)
     )
@@ -216,8 +216,8 @@ extends RegularizationEvaluation {
       }
       else acc
     val regularizeGain =
-      safeLiterals.ant.foldLeft(0..toFloat)(foldFunction(information.leftMap))  +
-      safeLiterals.suc.foldLeft(0..toFloat)(foldFunction(information.rightMap))
+      safeLiterals.ant.foldLeft(0.0.toFloat)(foldFunction(information.leftMap))  +
+      safeLiterals.suc.foldLeft(0.0.toFloat)(foldFunction(information.rightMap))
 //    println("Clever " + proof.conclusion + " with " + currentChildrenNumber + " children, size " +
 //            information.nodeSize + " reg " + regularizeGain)
     lowerInsteadOfRegularizeChooseOnWeight((currentChildrenNumber - 1).toFloat, regularizeGain)

--- a/src/main/scala/at/logic/skeptik/algorithm/compressor/oldUnitLowering.scala
+++ b/src/main/scala/at/logic/skeptik/algorithm/compressor/oldUnitLowering.scala
@@ -3,6 +3,7 @@ import at.logic.skeptik.proof.oldResolution._
 import at.logic.skeptik.proof.oldResolution.defs._
 import at.logic.skeptik.algorithm.compressor.ProofFixing._
 import collection._
+import language.postfixOps
 
 object UnitLowering {
 
@@ -54,7 +55,7 @@ object UnitLowering {
         p.pivot
         p
       } catch {
-        case _ => {println(u.clause + " failed to resolve"); proof}
+        case _: Throwable => {println(u.clause + " failed to resolve"); proof}
       }
       reinsertUnits(newRootProof, units)
     }

--- a/src/main/scala/at/logic/skeptik/experiment/compression/Algorithms.scala
+++ b/src/main/scala/at/logic/skeptik/experiment/compression/Algorithms.scala
@@ -19,7 +19,7 @@ extends WrappedAlgorithm(name)
   def experiment(p: P, eval: P => Report): Unit = {
     System.gc()
     val outProof = algorithm(p)
-    val curEval = eval(outProof) + ("duration.s" -> algorithm.duration.toDouble / 1000.)
+    val curEval = eval(outProof) + ("duration.s" -> algorithm.duration.toDouble / 1000.0)
     println(name + ": " + curEval)
     report = report add curEval
   }
@@ -57,14 +57,14 @@ trait Repeating[P] extends AbstractWrappedAlgorithm[P] {
     def rec(duration:Long, run:Int, ratio:Double, proof:P):Unit = {
       val newProof = algorithm(proof)
       val newDuration = duration + algorithm.duration
-      val curEval = eval(newProof) + ("duration.s" -> newDuration.toDouble / 1000.) + ("run" -> run.toDouble)
+      val curEval = eval(newProof) + ("duration.s" -> newDuration.toDouble / 1000.0) + ("run" -> run.toDouble)
       if (curEval("ratio.%") < ratio) rec(newDuration, run+1, curEval("ratio.%"), newProof)
       else {
         println(name + ": " + curEval)
         report = report add curEval
       }
     }
-    rec(0, 1, 100., p)
+    rec(0, 1, 100.0, p)
   }
 }
 

--- a/src/main/scala/at/logic/skeptik/experiment/compression/Experimenter.scala
+++ b/src/main/scala/at/logic/skeptik/experiment/compression/Experimenter.scala
@@ -187,7 +187,7 @@ object Experimenter {
           (new SimplePropositionalResolutionProofFormatParser(proofFilename)).getProof
         sequentMeasurer = measurerFactory.seqMeasurer(sequentProof)
       }
-      println(String.format(" (%.2f s)", double2Double((java.lang.System.currentTimeMillis - beginParsing)/1000.)))
+      println(String.format(" (%.2f s)", double2Double((java.lang.System.currentTimeMillis - beginParsing)/1000.0)))
 
       algos.foreach( _ match {
         case a: WrappedOldAlgorithm     => a.experiment(oldProof,     oldMeasurer)

--- a/src/main/scala/at/logic/skeptik/experiment/compression/Measures.scala
+++ b/src/main/scala/at/logic/skeptik/experiment/compression/Measures.scala
@@ -50,7 +50,7 @@ extends Map[String,Double] with MapLike[String,Double,Report] {
 }
 object Report {
   def apply(args: (String,Double)*) = {
-    val nargs = args ++ Array("num" -> 1.)
+    val nargs = args ++ Array("num" -> 1.0)
     new Report(HashMap(nargs: _*))
   }
 
@@ -98,7 +98,7 @@ class PercentMeasure[P] private (name: String, fct: (P) => Double)
 extends Measure[P]
 {
   def init( p:P, report:Report) = report + (name -> fct(p))
-  def apply(p:P, report:Report) = report + (name -> (100. * fct(p) / report(name)))
+  def apply(p:P, report:Report) = report + (name -> (100.0 * fct(p) / report(name)))
 }
 object PercentMeasure {
   def apply[P](name: String, fct: P => Double) = new PercentMeasure(name + ".%", fct)

--- a/src/main/scala/at/logic/skeptik/experiment/proving/ProverExperiment.scala
+++ b/src/main/scala/at/logic/skeptik/experiment/proving/ProverExperiment.scala
@@ -15,6 +15,7 @@ import at.logic.skeptik.judgment.{Judgment, Sequent, NamedE, NaturalSequent}
 import at.logic.skeptik.prover.SimpleProver
 import collection.mutable.{Map => MMap}
 import at.logic.skeptik.util.time._
+import language.implicitConversions
 
 import java.io.{File,PrintWriter}
 

--- a/src/main/scala/at/logic/skeptik/expression/formula/package.scala
+++ b/src/main/scala/at/logic/skeptik/expression/formula/package.scala
@@ -1,6 +1,7 @@
 package at.logic.skeptik.expression
 package object formula {
   import at.logic.skeptik.util.unicode._
+  import language.implicitConversions
 
   // Logical Symbols and Connectives
   

--- a/src/main/scala/at/logic/skeptik/expression/package.scala
+++ b/src/main/scala/at/logic/skeptik/expression/package.scala
@@ -1,6 +1,7 @@
 package at.logic.skeptik
   
 package object expression {
+  import language.implicitConversions
 
   implicit def enrichString(s: String) = new RichString(s)
   

--- a/src/main/scala/at/logic/skeptik/expression/position/positions.scala
+++ b/src/main/scala/at/logic/skeptik/expression/position/positions.scala
@@ -37,7 +37,7 @@ abstract class SinglePosition extends Position {
 }
 
 class IndexedPosition(p: Position, index: Int) extends SinglePosition {
-  def !:(e:E) = try { Some((e !!: p)(index)) } catch { case _ => None }
+  def !:(e:E) = try { Some((e !!: p)(index)) } catch { case _: Throwable => None }
   
   def @:(f: E => E)(e: E) = !:(e) match {
     case Some(sub) => (f @: new PredicatePosition(_ eq sub))(e)

--- a/src/main/scala/at/logic/skeptik/judgment/Sequent.scala
+++ b/src/main/scala/at/logic/skeptik/judgment/Sequent.scala
@@ -6,6 +6,7 @@ import collection.mutable.Stack
 import at.logic.skeptik.expression._
 import at.logic.skeptik.util.unicode._
 import at.logic.skeptik.expression.formula._
+import language.reflectiveCalls
 
 
 abstract class ASequent extends Judgment {

--- a/src/main/scala/at/logic/skeptik/proof/Proof.scala
+++ b/src/main/scala/at/logic/skeptik/proof/Proof.scala
@@ -1,8 +1,9 @@
 package at.logic.skeptik.proof
 
 import at.logic.skeptik.judgment.Judgment
+import scala.reflect.ClassTag
 
-abstract class Proof[+J <: Judgment, +P <: Proof[J,P] : ClassManifest] 
+abstract class Proof[+J <: Judgment, +P <: Proof[J,P] : ClassTag] 
 {
   def name = {val fullName = getClass.getName; fullName.substring(fullName.lastIndexOf('.' : Int))}
   private val self = asInstanceOf[P]

--- a/src/main/scala/at/logic/skeptik/proof/ProofNodeCollection.scala
+++ b/src/main/scala/at/logic/skeptik/proof/ProofNodeCollection.scala
@@ -1,6 +1,7 @@
 package at.logic.skeptik.proof
 
 import collection.mutable.{HashMap => MMap, HashSet => MSet, Stack}
+import scala.reflect.ClassTag
 
 
 // TODO: ProofNodeCollection is not really conforming to the standards of 
@@ -88,7 +89,7 @@ extends Iterable[P]
 }
 
 object ProofNodeCollection {
-  def apply[P <: Proof[_,P] : ClassManifest](root: P) = {
+  def apply[P <: Proof[_,P] : ClassTag](root: P) = {
     val nodes = Stack[P]()
     val children = MMap[P,List[P]]()
     val visited = MSet[P]()

--- a/src/main/scala/at/logic/skeptik/proof/natural/ContextualNDRules.scala
+++ b/src/main/scala/at/logic/skeptik/proof/natural/ContextualNDRules.scala
@@ -97,7 +97,7 @@ abstract class ImpIntroCRule extends InferenceRule[NaturalSequent, NaturalDeduct
           case i @ Imp(a,b) => {
             val deepAux = (premises(0).conclusion.e !: p).get
             if (b == deepAux) premises(0).conclusion.context.find(_.expression == a) match {
-              case Some(assumption) => try { Some(apply(premises(0), assumption, p)) } catch {case _ => None}
+              case Some(assumption) => try { Some(apply(premises(0), assumption, p)) } catch {case _: Throwable => None}
               case None => None
             }
             else None   

--- a/src/main/scala/at/logic/skeptik/prover/SimpleProver.scala
+++ b/src/main/scala/at/logic/skeptik/prover/SimpleProver.scala
@@ -5,9 +5,10 @@ import at.logic.skeptik.judgment.Judgment
 import at.logic.skeptik.proof.ProofNodeCollection
 import at.logic.skeptik.util.debug._
 import at.logic.skeptik.util.argMin
+import scala.reflect.ClassTag
 
 // ToDo: (B) Use futures and Map from (goal, inference) to future to create DAG-proof!
-class SimpleProver[J <: Judgment, P <: Proof[J,P]: ClassManifest](calculus: Calculus[J,P]) {
+class SimpleProver[J <: Judgment, P <: Proof[J,P]: ClassTag](calculus: Calculus[J,P]) {
   def prove(goal:J, timeout: Long = Long.MaxValue) : Option[P] = {
     val deadline = System.nanoTime + timeout * 1000000 
     


### PR DESCRIPTION
Upgrade to scala-2.10.0-M5 (motivated by new Scaladoc diagrams and implicits features)
- fix warnings and deprecations
- fix pom.xml

To generate the Scaladoc : mvn scala:doc

WARNING : sbt (version >= 0.13) is now required
