### PR TITLE
Fixing extension from ProofParser to ProofCombinatorParser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,8 @@ experiments/compressor/slice*
 *.synctex.gz
 /.scala_dependencies
 examples/proofs/VeriT/bad
+
+# Common files generated during first building
+examples/proofs/VeriT/eq_diamond9-(D-RPI-LU).smt2
+examples/proofs/VeriT/eq_diamond9-RP.smt2
+skeptik.jar

--- a/src/main/scala/at/logic/skeptik/parser/ParserTPTP.scala
+++ b/src/main/scala/at/logic/skeptik/parser/ParserTPTP.scala
@@ -10,7 +10,8 @@ import at.logic.skeptik.expression.formula._
 import at.logic.skeptik.expression._
 import at.logic.skeptik.judgment.immutable.{SeqSequent => Sequent}
 
-object ParserTPTP extends ProofParser[Node] with ParserTPTP
+object ParserTPTP extends ProofCombinatorParser[Node] with ParserTPTP
+
 
 trait ParserTPTP
 extends JavaTokenParsers with RegexParsers {
@@ -18,7 +19,9 @@ extends JavaTokenParsers with RegexParsers {
   private var proofMap = new MMap[String,Node]
   private var exprMap = new MMap[String,E]
   private var varMap = new MMap[String,E]
-  
+
+  def reset(): Unit = ()
+
   //Note (jgorzny; 27 Apr 2016):
   //I don't think this parser was ever completed or used (in whatever state it exists in)
   //Use *only* after testing; the TODOs below suggest some work needs to be done.

--- a/src/main/scala/at/logic/skeptik/parser/ProofParserLFSC.scala
+++ b/src/main/scala/at/logic/skeptik/parser/ProofParserLFSC.scala
@@ -10,7 +10,8 @@ import at.logic.skeptik.expression.formula._
 import at.logic.skeptik.expression._
 import at.logic.skeptik.judgment.immutable.{SeqSequent => Sequent}
 
-object ProofParserLFSC extends ProofParser[Node] with LFSCParsers
+object ProofParserLFSC extends ProofCombinatorParser[Node] with LFSCParsers
+
 
 trait LFSCParsers
 extends JavaTokenParsers with RegexParsers {
@@ -18,7 +19,9 @@ extends JavaTokenParsers with RegexParsers {
   private var proofMap = new MMap[String,Node]
   private var exprMap = new MMap[String,E]
   private var varMap = new MMap[String,E]
-  
+
+  def reset(): Unit = ()
+
   //returns the actual proof
  def proof: Parser[Proof[Node]] = "(check " ~ rep(varDecl) ~ ")" ^^ {   
  	case ~(~(_,list),_)=>{ //ignore everything but the clauses (which will include the resolutions)

--- a/src/main/scala/at/logic/skeptik/parser/ProofParserSPASS.scala
+++ b/src/main/scala/at/logic/skeptik/parser/ProofParserSPASS.scala
@@ -14,7 +14,7 @@ import at.logic.skeptik.judgment.immutable.{ SeqSequent => Sequent }
 import at.logic.skeptik.proof.sequent.resolution._
 import at.logic.skeptik.expression.substitution.immutable.Substitution
 
-object ProofParserSPASS extends ProofParser[Node] with SPASSParsers
+object ProofParserSPASS extends ProofCombinatorParser[Node] with SPASSParsers
 
 trait SPASSParsers
   extends JavaTokenParsers with RegexParsers with checkUnifiableVariableName {
@@ -29,6 +29,8 @@ trait SPASSParsers
   private val exprMap = new MMap[String, E] //will map axioms/proven expressions to the location (line number) where they were proven
 
   private val varMap = new MMap[String, E] //will map variable names to an expression object for that variable
+
+  def reset(): Unit = ()
 
   //returns the actual proof
   def proof: Parser[Proof[Node]] = rep(line) ^^ {


### PR DESCRIPTION
I changed the extension from ProofParser to ProofCombinatorParser in the SPASS, TPTP and LFSC parsers.
I had to implement a default reset method in the three parsers that do nothing.
This should be checked, I assumed that as it wasn't defined before this change, it is not used in the actual implementations. An issue to review this and correctly implement the method should be created.

I also changed the .gitignore to add a few files.
