### PR TITLE
TPTP parsers implementation

### DIFF
--- a/examples/problems/Axioms/SYN000+0.ax
+++ b/examples/problems/Axioms/SYN000+0.ax
@@ -1,0 +1,37 @@
+%------------------------------------------------------------------------------
+% File     : SYN000+0 : TPTP v6.3.0. Released v3.6.0.
+% Domain   : Syntactic
+% Axioms   : A simple include file for FOF
+% Version  : Biased.
+% English  :
+
+% Refs     :
+% Source   : [TPTP]
+% Names    :
+
+% Status   : Satisfiable
+% Syntax   : Number of formulae    :    3 (   3 unit)
+%            Number of atoms       :    3 (   0 equality)
+%            Maximal formula depth :    1 (   1 average)
+%            Number of connectives :    0 (   0 ~  ;   0  |;   0  &)
+%                                         (   0 <=>;   0 =>;   0 <=)
+%                                         (   0 <~>;   0 ~|;   0 ~&)
+%            Number of predicates  :    3 (   3 propositional; 0-0 arity)
+%            Number of functors    :    0 (   0 constant; --- arity)
+%            Number of variables   :    0 (   0 singleton;   0 !;   0 ?)
+%            Maximal term depth    :    0 (   0 average)
+% SPC      :
+
+% Comments :
+%------------------------------------------------------------------------------
+%----Some axioms to include
+fof(ia1,axiom,
+    ia1).
+
+fof(ia2,axiom,
+    ia2).
+
+fof(ia3,axiom,
+    ia3).
+
+%------------------------------------------------------------------------------

--- a/examples/problems/Axioms/SYN000-0.ax
+++ b/examples/problems/Axioms/SYN000-0.ax
@@ -1,0 +1,34 @@
+%------------------------------------------------------------------------------
+% File     : SYN000-0 : TPTP v6.3.0. Released v3.6.0.
+% Domain   : Syntactic
+% Axioms   : A simple include file for CNF
+% Version  : Biased.
+% English  :
+
+% Refs     :
+% Source   : [TPTP]
+% Names    :
+
+% Status   : Satisfiable
+% Syntax   : Number of clauses     :    3 (   0 non-Horn;   3 unit;   3 RR)
+%            Number of atoms       :    3 (   0 equality)
+%            Maximal clause size   :    1 (   1 average)
+%            Number of predicates  :    3 (   3 propositional; 0-0 arity)
+%            Number of functors    :    0 (   0 constant; --- arity)
+%            Number of variables   :    0 (   0 singleton)
+%            Maximal term depth    :    0 (   0 average)
+% SPC      :
+
+% Comments :
+%------------------------------------------------------------------------------
+%----Some axioms to include
+cnf(ia1,axiom,
+    ia1).
+
+cnf(ia2,axiom,
+    ia2).
+
+cnf(ia3,axiom,
+    ia3).
+
+%------------------------------------------------------------------------------

--- a/examples/problems/CNF/CNF.cnfp
+++ b/examples/problems/CNF/CNF.cnfp
@@ -1,0 +1,83 @@
+%------------------------------------------------------------------------------
+% File     : SYN000-1 : TPTP v6.3.0. Released v4.0.0.
+% Domain   : Syntactic
+% Problem  : Basic TPTP CNF syntax
+% Version  : Biased.
+% English  : Basic TPTP CNF syntax that you can't survive without parsing.
+
+% Refs     :
+% Source   : [TPTP]
+% Names    :
+
+% Status   : Unsatisfiable
+% Rating   : 0.27 v6.2.0, 0.40 v6.1.0, 0.36 v6.0.0, 0.50 v5.4.0, 0.55 v5.3.0, 0.56 v5.2.0, 0.62 v5.1.0, 0.65 v5.0.0, 0.64 v4.1.0, 0.62 v4.0.1, 0.64 v4.0.0
+% Syntax   : Number of clauses     :   11 (   6 non-Horn;   5 unit;   7 RR)
+%            Number of atoms       :   27 (   3 equality)
+%            Maximal clause size   :    5 (   2 average)
+%            Number of predicates  :   16 (  10 propositional; 0-3 arity)
+%            Number of functors    :    8 (   5 constant; 0-3 arity)
+%            Number of variables   :   11 (   5 singleton)
+%            Maximal term depth    :    4 (   2 average)
+% SPC      : CNF_UNS_RFO_SEQ_NHN
+
+% Comments :
+%------------------------------------------------------------------------------
+%----Propositional
+cnf(propositional,axiom,
+    ( p0
+    | ~ q0
+    | r0
+    | ~ s0 )).
+
+%----First-order
+cnf(first_order,axiom,
+    ( p(X)
+    | ~ q(X,a)
+    | r(X,f(Y),g(X,f(Y),Z))
+    | ~ s(f(f(f(b)))) )).
+
+%----Equality
+cnf(equality,axiom,
+    ( f(Y) = g(X,f(Y),Z)
+    | f(f(f(b))) != a
+    | X = f(Y) )).
+
+%----True and false
+cnf(true_false,axiom,
+    ( $true
+    | $false )).
+
+%----Quoted symbols
+cnf(single_quoted,axiom,
+    ( 'A proposition'
+    | 'A predicate'(Y)
+    | p('A constant')
+    | p('A function'(a))
+    | p('A \'quoted \\ escape\'') )).
+
+%----Connectives - seen them all already
+
+%----Annotated formula names
+cnf(123,axiom,
+    ( p(X)
+    | ~ q(X,a)
+    | r(X,f(Y),g(X,f(Y),Z))
+    | ~ s(f(f(f(b)))) )).
+
+%----Roles - seen axiom already
+cnf(role_hypothesis,hypothesis,
+    p(h)).
+
+cnf(role_negated_conjecture,negated_conjecture,
+    ~ p(X)).
+
+%----Include directive
+include('examples/problems/Axioms/SYN000-0.ax').
+
+%----Comments
+/* This
+   is a block
+   comment.
+*/
+
+%------------------------------------------------------------------------------

--- a/examples/problems/FOF/FOF.fofp
+++ b/examples/problems/FOF/FOF.fofp
@@ -1,0 +1,99 @@
+%------------------------------------------------------------------------------
+% File     : SYN000+1 : TPTP v6.3.0. Released v4.0.0.
+% Domain   : Syntactic
+% Problem  : Basic TPTP FOF syntax
+% Version  : Biased.
+% English  : Basic TPTP FOF syntax that you can't survive without parsing.
+
+% Refs     :
+% Source   : [TPTP]
+% Names    :
+
+% Status   : Theorem
+% Rating   : 0.19 v6.3.0, 0.25 v6.2.0, 0.28 v6.1.0, 0.33 v6.0.0, 0.43 v5.5.0, 0.48 v5.4.0, 0.46 v5.3.0, 0.52 v5.2.0, 0.40 v5.1.0, 0.43 v5.0.0, 0.54 v4.1.0, 0.57 v4.0.1, 0.78 v4.0.0
+% Syntax   : Number of formulae    :   12 (   5 unit)
+%            Number of atoms       :   31 (   3 equality)
+%            Maximal formula depth :    7 (   4 average)
+%            Number of connectives :   28 (   9   ~;  10   |;   3   &)
+%                                         (   1 <=>;   3  =>;   1  <=)
+%                                         (   1 <~>;   0  ~|;   0  ~&)
+%            Number of predicates  :   16 (  10 propositional; 0-3 arity)
+%            Number of functors    :    8 (   5 constant; 0-3 arity)
+%            Number of variables   :   13 (   0 sgn;   5   !;   8   ?)
+%            Maximal term depth    :    4 (   2 average)
+% SPC      : FOF_THM_RFO_SEQ
+
+% Comments :
+%------------------------------------------------------------------------------
+%----Propositional
+fof(propositional,axiom,
+    ( ( p0
+      & ~ q0 )
+   => ( r0
+      | ~ s0 ) )).
+
+%----First-order
+fof(first_order,axiom,(
+    ! [X] :
+      ( ( p(X)
+        | ~ q(X,a) )
+     => ? [Y,Z] :
+          ( r(X,f(Y),g(X,f(Y),Z))
+          & ~ s(f(f(f(b)))) ) ) )).
+
+%----Equality
+fof(equality,axiom,(
+    ? [Y] :
+    ! [X,Z] :
+      ( f(Y) = g(X,f(Y),Z)
+      | f(f(f(b))) != a
+      | X = f(Y) ) )).
+
+%----True and false
+fof(true_false,axiom,
+    ( $true
+    | $false )).
+
+%----Quoted symbols
+fof(single_quoted,axiom,
+    ( 'A proposition'
+    | 'A predicate'(a)
+    | p('A constant')
+    | p('A function'(a))
+    | p('A \'quoted \\ escape\'') )).
+
+%----Connectives - seen |, &, =>, ~ already
+fof(useful_connectives,axiom,(
+    ! [X] :
+      ( ( p(X)
+       <= ~ q(X,a) )
+    <=> ? [Y,Z] :
+          ( r(X,f(Y),g(X,f(Y),Z))
+        <~> ~ s(f(f(f(b)))) ) ) )).
+
+%----Annotated formula names
+fof(123,axiom,(
+    ! [X] :
+      ( ( p(X)
+        | ~ q(X,a) )
+     => ? [Y,Z] :
+          ( r(X,f(Y),g(X,f(Y),Z))
+          & ~ s(f(f(f(b)))) ) ) )).
+
+%----Roles
+fof(role_hypothesis,hypothesis,(
+    p(h) )).
+
+fof(role_conjecture,conjecture,(
+    ? [X] : p(X) )).
+
+%----Include directive
+include('examples/problems/Axioms/SYN000+0.ax').
+
+%----Comments
+/* This
+   is a block
+   comment.
+*/
+
+%------------------------------------------------------------------------------

--- a/src/main/scala/at/logic/skeptik/expression/formula/formulas.scala
+++ b/src/main/scala/at/logic/skeptik/expression/formula/formulas.scala
@@ -81,10 +81,9 @@ object Atom extends Formula {
 }
 
 object ConditionalFormula extends Formula{
-  require(conditionalConectiveS == "conditionalFormula") // This is done to check consistency in the unapply method
-  def apply(cond : E, f1 : E, f2 : E) : E = AppRec(conditionalConectiveC,List(cond,f1,f2))
+  def apply(cond : E, f1 : E, f2 : E) : E = AppRec(conditionalConnectiveC,List(cond,f1,f2))
   override def unapply(f: E): Option[_] = f match {
-    case AppRec(Var("conditionalFormula",_),List(cond,f1,f2)) => Some((cond,f1,f2))
+    case AppRec(Var(n,_),List(cond,f1,f2)) if n == conditionalConnectiveS => Some((cond,f1,f2))
     case _                                                    => None
   }
 }

--- a/src/main/scala/at/logic/skeptik/expression/formula/formulas.scala
+++ b/src/main/scala/at/logic/skeptik/expression/formula/formulas.scala
@@ -57,9 +57,27 @@ object Atom extends Formula {
     require(atom.t == o)
     atom
   }
+  def apply(name: String, args: List[E]) = {
+    def createType(arity : Int) : T = {
+      if (arity == 0) o
+      else i -> createType(arity -1)
+    }
+    val p    = Var(name,createType(args.length))
+    val atom = AppRec(p,args)
+    require(atom.t == o)
+    atom
+  }
   def unapply(e:E) = e match {
     case AppRec(f,args) if (e.t == o && !isLogicalConnective(f)) => Some((f,args))
     case _ => None
   }
 }
 
+object ConditionalFormula extends Formula{
+  require(conditionalConectiveS == "conditionalFormula") // This is done to check consistency in the unapply method
+  def apply(cond : E, f1 : E, f2 : E) : E = AppRec(conditionalConectiveC,List(cond,f1,f2))
+  override def unapply(f: E): Option[_] = f match {
+    case AppRec(Var("conditionalFormula",_),List(cond,f1,f2)) => Some((cond,f1,f2))
+    case _                                                    => None
+  }
+}

--- a/src/main/scala/at/logic/skeptik/expression/formula/formulas.scala
+++ b/src/main/scala/at/logic/skeptik/expression/formula/formulas.scala
@@ -30,8 +30,15 @@ abstract class QuantifierFormula(quantifierC:T=>E) extends Formula {
     val h = (( (_:E) => v.copy) @: p)(f)
     App(quantifierC(v.t), Abs(v,h))
   }
-  def apply(f:E, v:Var, t:E): E = apply(f, v, new PredicatePosition(_ == t)) 
-    
+  def apply(f:E, v:Var, t:E): E = apply(f, v, new PredicatePosition(_ == t))
+
+  def apply(vars : List[Var], f : E) : E = {
+    require(vars.nonEmpty)
+    val (head,tail) = (vars.head, vars.tail)
+    if (vars.length == 1) apply(head,f)
+    else apply(head,apply(tail,f))
+  }
+
   def unapply(e:E) = e match {
     case App(q, Abs(v,f)) if q == quantifierC(v.t) => Some((v,f))
     case _ => None
@@ -81,3 +88,9 @@ object ConditionalFormula extends Formula{
     case _                                                    => None
   }
 }
+
+object FormulaEquality extends BinaryFormula(eqC(o))
+
+
+object Equivalence extends BinaryFormula(equivC)
+

--- a/src/main/scala/at/logic/skeptik/expression/formula/formulas.scala
+++ b/src/main/scala/at/logic/skeptik/expression/formula/formulas.scala
@@ -88,7 +88,9 @@ object ConditionalFormula extends Formula{
   }
 }
 
-object FormulaEquality extends BinaryFormula(eqC(i))
+object FormulaEquality extends BinaryFormula(eqC(i)){
+  def apply(t:T)(left : E, right : E) = App(App(new Var(eqS, t -> (t -> o)) with Infix,left),right)
+}
 
 
 object Equivalence extends BinaryFormula(equivC)

--- a/src/main/scala/at/logic/skeptik/expression/formula/formulas.scala
+++ b/src/main/scala/at/logic/skeptik/expression/formula/formulas.scala
@@ -65,11 +65,11 @@ object Atom extends Formula {
     atom
   }
   def apply(name: String, args: List[E]) = {
-    def createType(arity : Int) : T = {
-      if (arity == 0) o
-      else i -> createType(arity -1)
+    def createType(list : List[E]) : T = list match {
+      case Nil   => o
+      case e::es => e.t -> createType(es)
     }
-    val p    = Var(name,createType(args.length))
+    val p    = Var(name,createType(args))
     val atom = AppRec(p,args)
     require(atom.t == o)
     atom
@@ -88,8 +88,15 @@ object ConditionalFormula extends Formula{
   }
 }
 
-object FormulaEquality extends BinaryFormula(eqC(o))
+object FormulaEquality extends BinaryFormula(eqC(i))
 
 
 object Equivalence extends BinaryFormula(equivC)
 
+object True {
+  def apply : E = new Var("True",o)
+}
+
+object False {
+  def apply : E = new Var("False",o)
+}

--- a/src/main/scala/at/logic/skeptik/expression/formula/package.scala
+++ b/src/main/scala/at/logic/skeptik/expression/formula/package.scala
@@ -39,12 +39,13 @@ package object formula {
   val equivS = "<=>"
   def equivC = new Var(equivS, (o -> (o -> o))) with Infix
 
-  val conditionalConectiveS = "conditionalFormula"
-  val conditionalConectiveC = new Var(conditionalConectiveS,o->(o->(o->o)))
+  val conditionalConnectiveS = "conditionalFormula"
+  val conditionalConnectiveC = new Var(conditionalConnectiveS,o->(o->(o->o)))
 
   def isLogicalConnective(c:E) = c match {
-    case Var(n,_) if (n == andS || n == orS || n == impS || 
-                      n == allS || n == exS || n == negS) => true
+    case Var(n,_) =>  n == andS || n == orS || n == impS ||
+                      n == allS || n == exS || n == negS ||
+                      n == conditionalConnectiveS
     case _ => false
   }
   

--- a/src/main/scala/at/logic/skeptik/expression/formula/package.scala
+++ b/src/main/scala/at/logic/skeptik/expression/formula/package.scala
@@ -36,6 +36,9 @@ package object formula {
   val eqS = "="
   def eqC(t:T) = new Var(eqS, (t -> (t -> o))) with Infix
 
+  val equivS = "<=>"
+  def equivC = new Var(equivS, (o -> (o -> o))) with Infix
+
   val conditionalConectiveS = "conditionalFormula"
   val conditionalConectiveC = new Var(conditionalConectiveS,o->(o->(o->o)))
 

--- a/src/main/scala/at/logic/skeptik/expression/formula/package.scala
+++ b/src/main/scala/at/logic/skeptik/expression/formula/package.scala
@@ -45,7 +45,7 @@ package object formula {
   def isLogicalConnective(c:E) = c match {
     case Var(n,_) =>  n == andS || n == orS || n == impS ||
                       n == allS || n == exS || n == negS ||
-                      n == conditionalConnectiveS
+                      n == equivS || n == conditionalConnectiveS
     case _ => false
   }
   

--- a/src/main/scala/at/logic/skeptik/expression/formula/package.scala
+++ b/src/main/scala/at/logic/skeptik/expression/formula/package.scala
@@ -34,8 +34,11 @@ package object formula {
   val negC = Var(negS, o -> o)
   
   val eqS = "="
-  def eqC(t:T) = new Var(eqS, (t -> (t -> o))) with Infix 
-  
+  def eqC(t:T) = new Var(eqS, (t -> (t -> o))) with Infix
+
+  val conditionalConectiveS = "conditionalFormula"
+  val conditionalConectiveC = new Var(conditionalConectiveS,o->(o->(o->o)))
+
   def isLogicalConnective(c:E) = c match {
     case Var(n,_) if (n == andS || n == orS || n == impS || 
                       n == allS || n == exS || n == negS) => true

--- a/src/main/scala/at/logic/skeptik/expression/term/terms.scala
+++ b/src/main/scala/at/logic/skeptik/expression/term/terms.scala
@@ -40,7 +40,7 @@ object FunctionTerm extends Term {
   }
 }
 
-object TypepNumberTerm extends Term {
+object TypedNumberTerm extends Term {
   def apply(number : String, numberType : String) : E = newTerm(number,new AtomicType(numberType))
 }
 

--- a/src/main/scala/at/logic/skeptik/expression/term/terms.scala
+++ b/src/main/scala/at/logic/skeptik/expression/term/terms.scala
@@ -1,0 +1,65 @@
+package at.logic.skeptik.expression.term
+
+import at.logic.skeptik.expression.{AppRec, AtomicType, E, T, Var, i, o}
+
+/**
+  * Objects to facilitate the creation of logical terms.
+  *
+  * @author Ezequiel Postan
+  * @since 24.05.2016
+  */
+class Term {
+  final val conditional = "conditionalTerm"
+  final val ifThenElse  = new Var(conditional,o->(i->(i->i)))
+  def newTerm(name : String, termType : T) = new Var(name,termType)
+}
+
+object DistinctObjectTerm extends Term {
+  def apply(name : String) :E = newTerm(name,i)
+}
+
+object NumberTerm extends Term {
+  def apply(number : String) :E = newTerm(number,i)
+}
+
+object Constant extends Term {
+  def apply(name : String) : E = newTerm(name,i)
+}
+
+object Variable extends Term {
+  def apply(name : String) : E = newTerm(name,i)
+}
+
+object FunctionTerm extends Term {
+  def apply(name : String, args : List[E]) : E = {
+    def createType(arity : Int) : T = {
+      if (arity == 0) i
+      else i -> createType(arity -1)
+    }
+    newTerm(name,createType(args.length))
+  }
+}
+
+object TypepNumberTerm extends Term {
+  def apply(number : String, numberType : String) : E = newTerm(number,new AtomicType(numberType))
+}
+
+object TypedConstant extends Term {
+  def apply(name : String, constantType : T) : E = newTerm(name,constantType)
+}
+
+object TypedVariable extends Term {
+  def apply(name : String, variableType : T) : E = newTerm(name,variableType)
+}
+
+object TypedFunctionSymbol extends Term {
+  def apply(name : String, functionSymbolType : T) : E = newTerm(name,functionSymbolType)
+}
+
+object ConditionalTerm extends Term {
+  def apply(condition : E , t1 : E, t2 : E) : E = {
+    AppRec(ifThenElse,List(condition,t1,t2))
+  }
+}
+
+

--- a/src/main/scala/at/logic/skeptik/expression/term/terms.scala
+++ b/src/main/scala/at/logic/skeptik/expression/term/terms.scala
@@ -32,11 +32,11 @@ object Variable extends Term {
 
 object FunctionTerm extends Term {
   def apply(name : String, args : List[E]) : E = {
-    def createType(arity : Int) : T = {
-      if (arity == 0) i
-      else i -> createType(arity -1)
+    def createType(list : List[E]) : T = list match {
+      case Nil   => i
+      case e::es => e.t -> createType(es)
     }
-    newTerm(name,createType(args.length))
+    AppRec(newTerm(name,createType(args)),args)
   }
 }
 

--- a/src/main/scala/at/logic/skeptik/parser/ParserTPTP.scala
+++ b/src/main/scala/at/logic/skeptik/parser/ParserTPTP.scala
@@ -1,12 +1,18 @@
 package at.logic.skeptik.parser
 
-import scala.util.parsing.combinator._
+
 import collection.mutable.{HashMap => MMap}
 import at.logic.skeptik.proof.Proof
 import at.logic.skeptik.proof.sequent.{SequentProofNode => Node}
-import at.logic.skeptik.proof.sequent.lk.{R, Axiom, UncheckedInference}
+import at.logic.skeptik.proof.sequent.lk.{Axiom, R, UncheckedInference}
 import at.logic.skeptik.expression._
 import at.logic.skeptik.judgment.immutable.{SeqSequent => Sequent}
+import at.logic.skeptik.parser.TPTPParsers.{TPTPLexical, TPTPTokens}
+
+import scala.util.parsing.combinator.syntactical.TokenParsers
+import scala.util.parsing.combinator.PackratParsers
+import scala.util.parsing.input.Reader
+
 
 /**
   * This modules describe the TPTP syntax as descrobed in
@@ -20,8 +26,10 @@ import at.logic.skeptik.judgment.immutable.{SeqSequent => Sequent}
   */
 
 class UnexpectedEmptyTPTPFileException extends Exception("Unexpected Empty File")
+class TPTPExtractException extends Exception("Unexpected Extract Exception")
 
-object ProofParserTPTP   extends ProofCombinatorParser[Node] with ProofParserTPTP
+
+object ProofParserTPTP   extends ProofParser[Node] with ProofParserTPTP
 object ProblemParserTPTP extends ProblemParserTPTP
 
 /**
@@ -29,34 +37,157 @@ object ProblemParserTPTP extends ProblemParserTPTP
   * by problems and proof objects described by the TPTP syntax
   */
 trait BaseParserTPTP
-extends JavaTokenParsers with PackratParsers {
+extends TokenParsers with PackratParsers {
 
-  def fof_annotated = "fof" ~ "(" ~ name ~ "," ~ formula_role ~ "," ~ fof_logic_formula ~ opt(annotations) ~ ")" <~ "."
-  def cnf_annotated = "cnf" ~ "(" ~ name ~ "," ~ formula_role ~ "," ~ cnf_logic_formula ~ opt(annotations) ~ ")" <~ "."
-  def tff_annotated = "tff" ~ "(" ~ name ~ "," ~ formula_role ~ "," ~ tff_logic_formula ~ opt(annotations) ~ ")" <~ "."
-  def thf_annotated = "thf" ~ "(" ~ name ~ "," ~ formula_role ~ "," ~ thf_logic_formula ~ opt(annotations) ~ ")" <~ "."
-  def tpi_annotated = "tpi" ~ "(" ~ name ~ "," ~ formula_role ~ "," ~ tpi_logic_formula ~ opt(annotations) ~ ")" <~ "."
-  def tpi_logic_formula = fof_logic_formula
+  val  lexical = new TPTPLexical
+  type Tokens  = TPTPTokens
+
+  // Parsing methods
+  def parse[Target](input: String, parser: Parser[Target]) = {
+    val tokens = new lexical.Scanner(input)
+    phrase(parser)(tokens)
+  }
+
+  def parse[Target](input: Reader[Char], parser: Parser[Target]) = {
+    val tokens = new lexical.Scanner(input)
+    phrase(parser)(tokens)
+  }
+
+  def tokens(input: String) = {
+    new lexical.Scanner(input)
+  }
+
+  def tokens(input: Reader[Char]) = {
+    new lexical.Scanner(input)
+  }
 
 
-  def fof_logic_formula = ???
-  def cnf_logic_formula = ???
-  def tff_logic_formula = ???
-  def thf_logic_formula = ???
+  // Actual Parsers
+  import lexical._
 
-  def annotations  : PackratParser[String] = ???
+  def include: Parser[(String,List[String])] = (
+    (elem(Include) ~ elem(LeftParenthesis)) ~> elem("Single quoted", _.isInstanceOf[SingleQuoted])
+      ~ opt((elem(Comma) ~ elem(LeftBracket)) ~> repsep(name,elem(Comma)) <~ elem(RightBracket))
+      <~ (elem(RightParenthesis) ~ elem(Dot)) ^^ {
+      case SingleQuoted(data) ~ Some(names) => (data, names)
+      case SingleQuoted(data) ~     _       => (data, List.empty)
+    }
+  )
 
-  def name         : PackratParser[String] = atomic_word | wholeNumber
-  def formula_role : PackratParser[String] = "axiom" | "hypothesis" | "definition" | "assumption" |
-                                             "lemma" | "theorem" | "corollary" | "conjecture" |
-                                             "negated_conjecture" | "plain" | "type" | "fi_domain" |
-                                             "fi_functors" | "fi_predicates" | "unknown"
+  def annotatedPattern(languageToken : Token, expectedFormula : Parser[_]) =
+    (elem(languageToken) ~ elem(LeftParenthesis)) ~> name ~ (elem(Comma) ~> formula_role <~ elem(Comma)) ~ expectedFormula ~ annotations <~ elem(RightParenthesis) ~ elem(Dot) ^^ {
+      case name ~ role ~ formula ~ annotations => (name,role,formula,annotations)
+    }
 
-  def atomic_word   : PackratParser[String] = lower_word | single_quoted
-  def lower_word    : PackratParser[String] = regex("[a-z][a-zA-Z0-9_]*".r)
-  def single_quoted : PackratParser[String] = """'[^']*'""".r ^^ { _.drop(1).dropRight(1) }
+  def fof_annotated = annotatedPattern(FOF,fof_formula)
+  def cnf_annotated = annotatedPattern(CNF,cnf_formula)
+  def tff_annotated = annotatedPattern(TFF,tff_formula)
+  def thf_annotated = annotatedPattern(THF,thf_formula)
+  def tpi_annotated = annotatedPattern(TPI,tpi_formula)
 
-  def comments = ???
+
+  def name : Parser[String] = (
+    atomic_word
+    | elem("integer", _.isInstanceOf[Integer]) ^^ {_.chars}
+  )
+  def atomic_word: Parser[String] = (
+    elem("lower word", _.isInstanceOf[LowerWord]) ^^ {_.chars}
+    | elem("single quoted", _.isInstanceOf[SingleQuoted]) ^^ {_.chars}
+  )
+
+  def formula_role : PackratParser[String] = {
+    def isRecognizedAsFormulaRole(token : Token): Boolean = {
+      val acceptedRoles = List("axiom" , "hypothesis" , "definition" , "assumption" ,
+                               "lemma" , "theorem" , "corollary" , "conjecture",
+                               "negated_conjecture" , "plain" , "type" , "fi_domain" ,
+                               "fi_functors" , "fi_predicates" , "unknown")
+      token.isInstanceOf[LowerWord] &&  acceptedRoles.contains(token.chars)
+    }
+    val expectedWord = "axiom, hypothesis, definition, assumption, lemma, theorem, corollary, conjecture, " +
+                       "negated_conjecture, plain, type, fi_domain, fi_functors, fi_predicates or unknown"
+    elem(expectedWord, isRecognizedAsFormulaRole) ^^ {_.chars}
+  }
+
+  def annotations = failure("Annotation Paeser not defined")
+
+  /*
+  type Source       = String
+  type OptionalInfo = List[UsefulInfo]
+  type UsefulInfo   = (String,String)
+
+  def annotations : Parser[Option[(Source,OptionalInfo)]] =
+    opt(elem(Comma) ~> source ~ optional_info) ^^ {
+      case None => None
+      case Some(src ~ info) => Some((src,info))
+    }
+
+  def source : PackratParser[Source] = general_term
+  def optional_info : Parser[OptionalInfo] =  opt(elem(Comma) ~> useful_info) ^^ {
+    case None => List.empty
+    case Some(x) => x
+  }
+
+  def useful_info: Parser[List[UsefulInfo]] = general_list
+
+  // Non-logical data (GeneralTerm, General data)
+  def general_term: Parser[] = (
+          general_list                              ^^ {x => Commons.GeneralTerm(List(Right(x)))}
+      ||| general_data                              ^^ {x => Commons.GeneralTerm(List(Left(x)))}
+      ||| general_data ~ elem(Colon) ~ general_term ^^ {case data ~ _ ~ gterm => Commons.GeneralTerm(Left(data) :: gterm.term)}
+    )
+
+  def general_list: Parser[List[Commons.GeneralTerm]] =
+    elem(LeftBracket) ~> opt(general_terms) <~ elem(RightBracket) ^^ {
+      case Some(gt)   => gt
+      case _       => List.empty
+    }
+  def general_terms: Parser[List[Commons.GeneralTerm]] = rep1sep(general_term, elem(Comma))
+
+  def general_data: Parser[Commons.GeneralData] = (
+          atomic_word                                             ^^ {Commons.GWord(_)}
+      ||| general_function
+      ||| variable                                                ^^ {Commons.GVar(_)}
+      ||| number                                                  ^^ {Commons.GNumber(_)}
+      ||| elem("Distinct object", _.isInstanceOf[DistinctObject]) ^^ {x => Commons.GDistinct(x.chars)}
+      ||| formula_data                                             ^^ {Commons.GFormulaData(_)}
+    )
+
+  def variable: Parser[Commons.Variable] = elem("Upper word", _.isInstanceOf[UpperWord]) ^^ {_.chars}
+  def number: Parser[Commons.Number] = (
+        elem("Integer" , _.isInstanceOf[Integer] ) ^^ {case i => Commons.IntegerNumber(i.asInstanceOf[Integer].value)}
+      | elem("Real"    , _.isInstanceOf[Real]    ) ^^ {x => Commons.DoubleNumber((x.asInstanceOf[Real].coeff.toString + "E" + x.asInstanceOf[Real].exp.toString).toDouble)}
+      | elem("Rational", _.isInstanceOf[Rational]) ^^ {case r => Commons.RationalNumber(r.asInstanceOf[Rational].p,r.asInstanceOf[Rational].q)}
+    )
+
+  def general_function: Parser[Commons.GFunc] =
+    atomic_word ~ elem(LeftParenthesis) ~ general_terms ~ elem(RightParenthesis) ^^ {
+      case name ~ _ ~ args ~ _  => Commons.GFunc(name,args)
+    }
+
+  def formula_data: Parser[Commons.FormulaData] = (
+    (acceptIf(x => x.isInstanceOf[DollarWord] && x.chars.equals("$thf"))(_ => "Parse error in formulaData") ~ elem(LeftParenthesis)) ~>
+      thf_formula <~ elem(RightParenthesis) ^^ {Commons.THFData(_)}
+      | (acceptIf(x => x.isInstanceOf[DollarWord] && x.chars.equals("$tff"))(_ => "Parse error in formulaData") ~ elem(LeftParenthesis)) ~>
+      tff_formula <~ elem(RightParenthesis) ^^ {Commons.TFFData(_)}
+      | (acceptIf(x => x.isInstanceOf[DollarWord] && x.chars.equals("$fof"))(_ => "Parse error in formulaData") ~ elem(LeftParenthesis)) ~>
+      fof_formula <~ elem(RightParenthesis) ^^ {Commons.FOFData(_)}
+      | (acceptIf(x => x.isInstanceOf[DollarWord] && x.chars.equals("$cnf"))(_ => "Parse error in formulaData") ~ elem(LeftParenthesis)) ~>
+      cnf_formula <~ elem(RightParenthesis) ^^ {Commons.CNFData(_)}
+      | (acceptIf(x => x.isInstanceOf[DollarWord] && x.chars.equals("$fot"))(_ => "Parse error in formulaData") ~ elem(LeftParenthesis)) ~>
+      term <~ elem(RightParenthesis) ^^ {Commons.FOTData(_)}
+    )
+*/
+
+
+
+
+  // We finally have the different  formula parsers
+  def tpi_formula = fof_formula
+  def fof_formula = failure("fof_formula parser not implemented")
+  def cnf_formula = failure("cnf_formula parser not implemented")
+  def tff_formula = failure("tff_formula parser not implemented")
+  def thf_formula = failure("thf_formula parser not implemented")
+
 
 }
 
@@ -78,109 +209,27 @@ extends BaseParserTPTP {
   }
 
   //returns the actual proof
-  def proof: Parser[Proof[Node]] = TPTP_file ^^ {p => if (p.nonEmpty) p.last
-                                                      else throw new UnexpectedEmptyTPTPFileException
-                                                }
+  def proof: Parser[Proof[Node]] = TPTP_file ^^ { p => if (p.nonEmpty) p.last
+                                                       else throw new UnexpectedEmptyTPTPFileException                                       }
 
-  def TPTP_file  : PackratParser[List[Proof[Node]]] = rep(TPTP_input)
-  def TPTP_input : PackratParser[Proof[Node]] = annotated_formula | include
-
-  def include  = ???
-
-  def annotated_formula : PackratParser[Proof[Node]] = ???
-
-  /*
-  def cnfName: Parser[String] = name ^^ {
-    case _ => {
-      println("sos")
-      "sos"
+  def read(filename: String) : Proof[Node] = {
+    val p : Proof[Node] = parse(filename,proof) match {
+      case Success(p2,_)      => p2
+      case Error(message,_)   => throw new Exception("Error: " + message)
+      case Failure(message,_) => throw new Exception("Failure: " + message)
     }
-  }
-    
-  def cnfRole: Parser[String] = name ^^ {
-    case _ => {
-      println("axiom")
-      "axiom"
-    }
+    reset()
+    p
   }
 
-  def func: Parser[String] = equals | max | userDef | lessEquals | greaterEquals
-  
-  def equals: Parser[String] = "eq(" ~ term ~ "," ~ term ~ ")" ^^ {
-      case ~(~(~(~(_,first),_),second),_) => {
-      println("eq: " + first + " " + second)
-      "eq"
-    }
-  }
-  
-    def lessEquals: Parser[String] = "le(" ~ term ~ "," ~ term ~ ")" ^^ {
-      case ~(~(~(~(_,first),_),second),_) => {
-      println("le: " + first + " " + second)
-      "le"
-    }
-  }
-  
-    
-    def greaterEquals: Parser[String] = "ge(" ~ term ~ "," ~ term ~ ")" ^^ {
-      case ~(~(~(~(_,first),_),second),_) => {
-      println("ge: " + first + " " + second)
-      "ge"
-    }
-  }
-    
-  def max: Parser[String] = "max(" ~ term ~ "," ~ term ~ "," ~ term ~ ")" ^^ {
-    case _ => ""
-  }
-  
-  def userDef: Parser[String] = str ~ "(" ~ term ~ ")" ^^ {
-    case ~(~(~(s,_),t),_) => {
-      println("userdef: " + s)
-      s
-    }
-  }
-    
-  def num: Parser[String] = """\d+""".r ^^ { 
-    case a => {
-      println("num: " + a)
-      a
-    }
-  }
-  
-  def term: Parser[String] = ("(~ " ~ term ~ ")" | func | num | str) ^^ {
-    case _ => {
-      println("term")
-      ""
-    }
-  }
-    
-    
-  def cnfFormula: Parser[String] = term ~ "|" ~ term ~ "|" ~ term ^^ { //This is actually a disjunction in the BNF of TPTP, and as such, might not always have 3 conjunctions
-    case _ => {
-      println("line")
-      ""
-    }
-  }
-    
-  def cnf: Parser[List[Node]] = "cnf(" ~ cnfName ~ "," ~ cnfRole ~ "," ~ cnfFormula ~ ")." ^^{
-    case ~(~(~(_,_),m),_) => {
-      println("cnf")
-      List()//TODO: replace this
-    }
-  } 
-  
 
-    def str: Parser[String] = """[^ ():]+""".r ^^ {
-      case s => {
-        println("str: " + s)
-        s
-      }
-    }
-    
-    def name: Parser[String] = """[^ (){}:⊢,.=]+""".r ^^ {
-      case s => {
-        println("name: " + s)
-        s
-      }
-    }
-  */
+
+  def TPTP_file  : Parser[List[Proof[Node]]] = ???
+  def TPTP_input : Parser[Proof[Node]] = ???
+
+
+  def annotated_formula : Parser[Proof[Node]] = ???
+
 }
+
+

--- a/src/main/scala/at/logic/skeptik/parser/ParserTPTP.scala
+++ b/src/main/scala/at/logic/skeptik/parser/ParserTPTP.scala
@@ -146,18 +146,6 @@ extends TokenParsers with PackratParsers {
     )
 
   def formula_role : Parser[String] = elem("Lower word", _.isInstanceOf[LowerWord]) ^^ {_.chars}
-  /*{
-    def isRecognizedAsFormulaRole(token : Token): Boolean = {
-      val acceptedRoles = List("axiom" , "hypothesis" , "definition" , "assumption" ,
-                               "lemma" , "theorem" , "corollary" , "conjecture",
-                               "negated_conjecture" , "plain" , "type" , "fi_domain" ,
-                               "fi_functors" , "fi_predicates" , "unknown")
-      token.isInstanceOf[LowerWord] &&  acceptedRoles.contains(token.chars)
-    }
-    val expectedWord = "axiom, hypothesis, definition, assumption, lemma, theorem, corollary, conjecture, " +
-                       "negated_conjecture, plain, type, fi_domain, fi_functors, fi_predicates or unknown"
-    elem(expectedWord, isRecognizedAsFormulaRole) ^^ {_.chars}
-  }*/
 
   def annotations : Parser[Annotations] =
     opt(elem(Comma) ~> source ~ optional_info) ^^ {
@@ -361,7 +349,7 @@ extends TokenParsers with PackratParsers {
 
   def fof_unary_formula: Parser[E] = (
     unary_connective ~ fof_unitary_formula ^^ {case Tilde ~ formula => Neg(formula)}
-      | fol_infix_unary                        ^^ {case left  ~ right   => Neg(FormulaEquality(left,right))}
+      | fol_infix_unary                    ^^ {case left  ~ right   => Neg(FormulaEquality(i)(left,right))}
     )
 
   def unary_connective: Parser[Token] = elem(Tilde)
@@ -406,7 +394,7 @@ extends TokenParsers with PackratParsers {
   def literal: Parser[Either[E,E]] = (
     atomic_formula                      ^^ {Right(_)}
       ||| elem(Tilde) ~> atomic_formula ^^ {Left(_)}
-      ||| fol_infix_unary               ^^ {case left ~ right => Left(FormulaEquality(left,right))}
+      ||| fol_infix_unary               ^^ {case left ~ right => Left(FormulaEquality(i)(left,right))}
     )
 
   ////////////////////////////////////////////////////

--- a/src/main/scala/at/logic/skeptik/parser/ParserTPTP.scala
+++ b/src/main/scala/at/logic/skeptik/parser/ParserTPTP.scala
@@ -302,6 +302,10 @@ extends TokenParsers with PackratParsers {
   def fof_logic_formula : Parser[E] = fof_binary_formula ||| fof_unitary_formula
 
   def fof_binary_formula: Parser[E] = fof_binary_non_assoc ||| fof_binary_assoc
+
+  // TODO: Check if this interpretation of the meaning of the symbols is right
+  // p <~> q          is ¬ (p <=> q) where <=> is the equivalence
+  // p ~|q and p ~& q are ¬ (p \/ q) and ¬ (p /\ q) respectively
   def fof_binary_non_assoc: Parser[E] = fof_unitary_formula ~ binary_connective ~ fof_unitary_formula ^^ {
     case left ~ Leftrightarrow      ~ right => Equivalence(left,right)
     case left ~ Rightarrow          ~ right => Imp(left,right)

--- a/src/main/scala/at/logic/skeptik/parser/ParserTPTP.scala
+++ b/src/main/scala/at/logic/skeptik/parser/ParserTPTP.scala
@@ -50,6 +50,7 @@ extends TokenParsers with PackratParsers {
   private var varSet : Set[Var] = new MSet[Var]()
   private def recordVar(v : String) {varSet += new Var(v,i)}
   def getSeenVars : Set[Var] = varSet
+  def resetVarsSeen() : Unit = { varSet.clear() }
 
   val  lexical = new TPTPLexical
   type Tokens  = TPTPTokens

--- a/src/main/scala/at/logic/skeptik/parser/ParserTPTP.scala
+++ b/src/main/scala/at/logic/skeptik/parser/ParserTPTP.scala
@@ -222,7 +222,7 @@ extends TokenParsers with PackratParsers {
 
   def term: Parser[E] = (
     function_term
-      ||| variable         ^^ {recordVar(_);Variable(_)}
+      ||| variable         ^^ {x => {recordVar(x);Variable(x)}}
       ||| conditional_term
       ||| let_term
     )
@@ -342,7 +342,7 @@ extends TokenParsers with PackratParsers {
     )
 
   def fof_quantified_formula: Parser[E] =
-    fol_quantifier ~ elem(LeftBracket) ~ rep1sep(variable^^{recordVar(_);Variable(_).asInstanceOf[Var]},elem(Comma)) ~ elem(RightBracket) ~ elem(Colon) ~ fof_unitary_formula ^^ {
+    fol_quantifier ~ elem(LeftBracket) ~ rep1sep(variable^^{x => {recordVar(x);Variable(x).asInstanceOf[Var]}},elem(Comma)) ~ elem(RightBracket) ~ elem(Colon) ~ fof_unitary_formula ^^ {
       case Exclamationmark ~ _ ~ vars ~ _ ~ _ ~ matrix => All(vars,matrix)
       case Questionmark    ~ _ ~ vars ~ _ ~ _ ~ matrix => Ex(vars,matrix)
     }

--- a/src/main/scala/at/logic/skeptik/parser/ParserTPTP.scala
+++ b/src/main/scala/at/logic/skeptik/parser/ParserTPTP.scala
@@ -395,9 +395,11 @@ extends TokenParsers with PackratParsers {
       ||| disjunction ~ elem(VLine) ~ literal ^^ {case dis ~ _ ~ l => appendToListPair(l,dis)}
     )
 
-  private def appendToListPair[A,B](literal : Either[A,B], acumulators : (List[A],List[B])) : (List[A],List[B]) = literal match {
-    case Left(l)  => (acumulators._1 ++ List(l) , acumulators._2)
-    case Right(l) => (acumulators._1 , acumulators._2 ++ List(l))
+  private def appendToListPair(literal : Either[E,E], acumulators : (List[E],List[E])) : (List[E],List[E]) = literal match {
+    case Left(Var("$true",_))   => (acumulators._1 , acumulators._2)
+    case Left(l)                => (acumulators._1 ++ List(l) , acumulators._2)
+    case Right(Var("$false",_)) => (acumulators._1 , acumulators._2)
+    case Right(l)               => (acumulators._1 , acumulators._2 ++ List(l))
   }
 
 

--- a/src/main/scala/at/logic/skeptik/parser/ParserTPTP.scala
+++ b/src/main/scala/at/logic/skeptik/parser/ParserTPTP.scala
@@ -2,43 +2,94 @@ package at.logic.skeptik.parser
 
 import scala.util.parsing.combinator._
 import collection.mutable.{HashMap => MMap}
-import java.io.FileReader
 import at.logic.skeptik.proof.Proof
 import at.logic.skeptik.proof.sequent.{SequentProofNode => Node}
 import at.logic.skeptik.proof.sequent.lk.{R, Axiom, UncheckedInference}
-import at.logic.skeptik.expression.formula._
 import at.logic.skeptik.expression._
 import at.logic.skeptik.judgment.immutable.{SeqSequent => Sequent}
 
-object ParserTPTP extends ProofCombinatorParser[Node] with ParserTPTP
+/**
+  * This modules describe the TPTP syntax as descrobed in
+  * www.cs.miami.edu/~tptp/TPTP/SyntaxBNF.html
+  *
+  * The non terminals don't follow camelcase convention to
+  * reflect the grammar in a more natural way.
+  *
+  * @author Ezequiel Postan
+  * @since 23.05.2016
+  */
+
+class UnexpectedEmptyTPTPFileException extends Exception("Unexpected Empty File")
+
+object ProofParserTPTP   extends ProofCombinatorParser[Node] with ProofParserTPTP
+object ProblemParserTPTP extends ProblemParserTPTP
+
+/**
+  * The BaseParserTPTP implements the common parsers shared both
+  * by problems and proof objects described by the TPTP syntax
+  */
+trait BaseParserTPTP
+extends JavaTokenParsers with PackratParsers {
+
+  def fof_annotated = "fof" ~ "(" ~ name ~ "," ~ formula_role ~ "," ~ fof_logic_formula ~ opt(annotations) ~ ")" <~ "."
+  def cnf_annotated = "cnf" ~ "(" ~ name ~ "," ~ formula_role ~ "," ~ cnf_logic_formula ~ opt(annotations) ~ ")" <~ "."
+  def tff_annotated = "tff" ~ "(" ~ name ~ "," ~ formula_role ~ "," ~ tff_logic_formula ~ opt(annotations) ~ ")" <~ "."
+  def thf_annotated = "thf" ~ "(" ~ name ~ "," ~ formula_role ~ "," ~ thf_logic_formula ~ opt(annotations) ~ ")" <~ "."
+  def tpi_annotated = "tpi" ~ "(" ~ name ~ "," ~ formula_role ~ "," ~ tpi_logic_formula ~ opt(annotations) ~ ")" <~ "."
+  def tpi_logic_formula = fof_logic_formula
 
 
-trait ParserTPTP
-extends JavaTokenParsers with RegexParsers {
-  
+  def fof_logic_formula = ???
+  def cnf_logic_formula = ???
+  def tff_logic_formula = ???
+  def thf_logic_formula = ???
+
+  def annotations  : PackratParser[String] = ???
+
+  def name         : PackratParser[String] = atomic_word | wholeNumber
+  def formula_role : PackratParser[String] = "axiom" | "hypothesis" | "definition" | "assumption" |
+                                             "lemma" | "theorem" | "corollary" | "conjecture" |
+                                             "negated_conjecture" | "plain" | "type" | "fi_domain" |
+                                             "fi_functors" | "fi_predicates" | "unknown"
+
+  def atomic_word   : PackratParser[String] = lower_word | single_quoted
+  def lower_word    : PackratParser[String] = regex("[a-z][a-zA-Z0-9_]*".r)
+  def single_quoted : PackratParser[String] = """'[^']*'""".r ^^ { _.drop(1).dropRight(1) }
+
+  def comments = ???
+
+}
+
+trait ProblemParserTPTP
+extends BaseParserTPTP {
+}
+
+trait ProofParserTPTP
+extends BaseParserTPTP {
+
+  private var varMap   = new MMap[String,E]
+  private var exprMap  = new MMap[String,E]
   private var proofMap = new MMap[String,Node]
-  private var exprMap = new MMap[String,E]
-  private var varMap = new MMap[String,E]
 
-  def reset(): Unit = ()
-
-  //Note (jgorzny; 27 Apr 2016):
-  //I don't think this parser was ever completed or used (in whatever state it exists in)
-  //Use *only* after testing; the TODOs below suggest some work needs to be done.
-  
-  //TODO: remove debugging lines
-  //TODO: actually store the information; right now it parses the stuff and throws it away
-  
-  //returns the actual proof
- def proof: Parser[Proof[Node]] = rep(cnf) ^^ {   
- 	case list =>{ 
- 		val p = Proof((list.last).last)
- 		exprMap = new MMap[String,E]
- 		p
-    }
+  def reset() : Unit = {
+    varMap.clear()
+    exprMap.clear()
+    proofMap.clear()
   }
-  
-  
+
+  //returns the actual proof
+  def proof: Parser[Proof[Node]] = TPTP_file ^^ {p => if (p.nonEmpty) p.last
+                                                      else throw new UnexpectedEmptyTPTPFileException
+                                                }
+
+  def TPTP_file  : PackratParser[List[Proof[Node]]] = rep(TPTP_input)
+  def TPTP_input : PackratParser[Proof[Node]] = annotated_formula | include
+
+  def include  = ???
+
+  def annotated_formula : PackratParser[Proof[Node]] = ???
+
+  /*
   def cnfName: Parser[String] = name ^^ {
     case _ => {
       println("sos")
@@ -131,4 +182,5 @@ extends JavaTokenParsers with RegexParsers {
         s
       }
     }
+  */
 }

--- a/src/main/scala/at/logic/skeptik/parser/TPTPParsers/ProblemParserCNFTPTP.scala
+++ b/src/main/scala/at/logic/skeptik/parser/TPTPParsers/ProblemParserCNFTPTP.scala
@@ -1,0 +1,24 @@
+package at.logic.skeptik.parser.TPTPParsers
+
+import at.logic.skeptik.parser.BaseParserTPTP
+
+/**
+  * @author  Ezequiel Postan
+  * @since   24.05.2016
+  * @version 1.0
+  * @note    This version accepts only CNF formulas that are taken as axioms
+  *          except for a conjeture or negated conjeture. No derivation nodes
+  *          or other TPTP annotated formulas are accepted.
+  */
+object ProblemParserCNFTPTP extends ProblemParserCNFTPTP
+
+/**
+  * The ProblemParserFOFTPTP trait implements a parser for problems written
+  * in the TPTP CNF syntax. We assume that there are no derivation nodes in
+  * the parsed file, i.e. that we only have our axioms and a final conjecture.
+  *
+  * TODO: Add (if needed) the treatment for FOF formulas and skolemnization steps
+  */
+trait ProblemParserCNFTPTP
+  extends BaseParserTPTP {
+}

--- a/src/main/scala/at/logic/skeptik/parser/TPTPParsers/ProblemParserCNFTPTP.scala
+++ b/src/main/scala/at/logic/skeptik/parser/TPTPParsers/ProblemParserCNFTPTP.scala
@@ -48,12 +48,7 @@ extends BaseParserTPTP {
     }
 
 
-  def problem(fileName : String) : CNFProblem =
-    parse(fileName,problemParser) match {
-      case Success(p,_)       => p
-      case Error(message,_)   => throw new Exception("Error: " + message)
-      case Failure(message,_) => throw new Exception("Failure: " + message)
-    }
+  def problem(fileName : String) : CNFProblem = extract(fileName,problemParser)
 
 }
 

--- a/src/main/scala/at/logic/skeptik/parser/TPTPParsers/ProblemParserCNFTPTP.scala
+++ b/src/main/scala/at/logic/skeptik/parser/TPTPParsers/ProblemParserCNFTPTP.scala
@@ -1,6 +1,8 @@
 package at.logic.skeptik.parser.TPTPParsers
 
+import at.logic.skeptik.expression.E
 import at.logic.skeptik.parser.BaseParserTPTP
+import at.logic.skeptik.parser.TPTPParsers.TPTPAST.{AnnotatedFormula, SimpleSequent, TPTPDirective}
 
 /**
   * @author  Ezequiel Postan
@@ -20,5 +22,64 @@ object ProblemParserCNFTPTP extends ProblemParserCNFTPTP
   * TODO: Add (if needed) the treatment for FOF formulas and skolemnization steps
   */
 trait ProblemParserCNFTPTP
-  extends BaseParserTPTP {
+extends BaseParserTPTP {
+
+  def problemParser : Parser[CNFProblem] = TPTP_file ^^ generateProblem
+
+  def generateProblem(directives : List[TPTPDirective]) : CNFProblem = {
+    val expandedDirectives : List[TPTPDirective]         = expandIncludes(directives,TPTP_file)
+    val formulas   : List[(String,String,Seq[E],Seq[E])] = expandedDirectives map extractFormulas
+    val statements : List[CNFProblemStatement]           = formulas map ((t : (String,String,Seq[E],Seq[E])) => formulaToStatement(t._1,t._2,t._3,t._4))
+    CNFProblem(statements)
+  }
+
+
+  def extractFormulas(directive : TPTPDirective) : (String,String,Seq[E],Seq[E]) =
+    directive match {
+      case AnnotatedFormula(language,name,role,SimpleSequent(ant,suc),_) if language == lexical.CNF.chars => (name,role,ant,suc)
+      case _                                                                                              => throw new Exception("Unexpected Format")
+    }
+
+  def formulaToStatement(name : String, role : String, ant : Seq[E], suc : Seq[E]) : CNFProblemStatement =
+    role match {
+      case "conjecture"         => CNFConjectureStatement(name,ant.toList,suc.toList)
+      case "negated_conjecture" => CNFNegatedConjectureStatement(name,ant.toList,suc.toList)
+      case _                    => CNFAxiomStatement(name,ant.toList,suc.toList)
+    }
+
+
+  def problem(fileName : String) : CNFProblem =
+    parse(fileName,problemParser) match {
+      case Success(p,_)       => p
+      case Error(message,_)   => throw new Exception("Error: " + message)
+      case Failure(message,_) => throw new Exception("Failure: " + message)
+    }
+
+}
+
+class CNFProblem(val statements : List[CNFProblemStatement]) {
+  override def toString : String = statements.mkString("\n")
+}
+object CNFProblem {
+  def apply(statements: List[CNFProblemStatement]): CNFProblem = new CNFProblem(statements)
+}
+
+abstract class CNFProblemStatement
+case class CNFAxiomStatement(name : String, ant : List[E], suc : List[E]) extends CNFProblemStatement {
+  override def toString : String = {
+    val initialNegation = if (ant.isEmpty) "" else "~ "
+    "cnf("+name + ",axiom,{ " + initialNegation + ant.mkString(", ~ ") + " --> " + suc.mkString(",") +" })"
+  }
+}
+case class CNFConjectureStatement(name : String, ant : List[E], suc : List[E]) extends CNFProblemStatement {
+  override def toString : String = {
+    val initialNegation = if (ant.isEmpty) "" else "~ "
+    "cnf(" + name + ",conjecture,{ " + initialNegation + ant.mkString(", ~ ") + " --> " + suc.mkString(",") + "})"
+  }
+}
+case class CNFNegatedConjectureStatement(name : String, ant : List[E], suc : List[E]) extends CNFProblemStatement {
+  override def toString : String = {
+    val initialNegation = if (ant.isEmpty) "" else "~ "
+    "cnf(" + name + ",negated_conjecture,{ " + initialNegation + ant.mkString(", ~ ") + " --> " + suc.mkString(",") + "})"
+  }
 }

--- a/src/main/scala/at/logic/skeptik/parser/TPTPParsers/ProblemParserFOFTPTP.scala
+++ b/src/main/scala/at/logic/skeptik/parser/TPTPParsers/ProblemParserFOFTPTP.scala
@@ -1,0 +1,17 @@
+package at.logic.skeptik.parser.TPTPParsers
+
+import at.logic.skeptik.parser.BaseParserTPTP
+
+/**
+  * Created by eze on 2016.05.25..
+  */
+object ProblemParserFOFTPTP extends ProblemParserFOFTPTP
+
+/**
+  * The ProblemParserFOFTPTP trait implements a parser for problems written
+  * in the TPTP FOF syntax. We assume that there are no derivation nodes in
+  * the parsed file, i.e. that we only have our axioms and conjectures.
+  */
+trait ProblemParserFOFTPTP
+  extends BaseParserTPTP {
+}

--- a/src/main/scala/at/logic/skeptik/parser/TPTPParsers/ProblemParserFOFTPTP.scala
+++ b/src/main/scala/at/logic/skeptik/parser/TPTPParsers/ProblemParserFOFTPTP.scala
@@ -1,6 +1,8 @@
 package at.logic.skeptik.parser.TPTPParsers
 
+import at.logic.skeptik.expression.E
 import at.logic.skeptik.parser.BaseParserTPTP
+import at.logic.skeptik.parser.TPTPParsers.TPTPAST.{AnnotatedFormula, SimpleFormula, TPTPDirective}
 
 /**
   * Created by eze on 2016.05.25..
@@ -13,5 +15,55 @@ object ProblemParserFOFTPTP extends ProblemParserFOFTPTP
   * the parsed file, i.e. that we only have our axioms and conjectures.
   */
 trait ProblemParserFOFTPTP
-  extends BaseParserTPTP {
+extends BaseParserTPTP {
+
+  def problemParser : Parser[FOFProblem] = TPTP_file ^^ generateProblem
+
+  def generateProblem(directives : List[TPTPDirective]) : FOFProblem = {
+    val expandedDirectives : List[TPTPDirective] = expandIncludes(directives,TPTP_file)
+    val formulas   : List[(String,String,E)]     = expandedDirectives map extractFormulas
+    val statements : List[FOFProblemStatement]   = formulas map ((t : (String,String,E)) => formulaToStatement(t._1,t._2,t._3))
+    FOFProblem(statements)
+  }
+
+
+  def extractFormulas(directive : TPTPDirective) : (String,String,E) =
+    directive match {
+      case AnnotatedFormula(language,name,role,SimpleFormula(formula),_) if language == lexical.FOF.chars => (name,role,formula)
+      case _                                                                                              => throw new Exception("Unexpected Format")
+    }
+
+  def formulaToStatement(name : String, role : String, formula : E) : FOFProblemStatement =
+    role match {
+      case "conjecture"         => ConjectureStatement(name,formula)
+      case "negated_conjecture" => NegatedConjectureStatement(name,formula)
+      case _                    => AxiomStatement(name,formula)
+    }
+
+
+  def problem(fileName : String) : FOFProblem =
+    parse(fileName,problemParser) match {
+      case Success(p,_)       => p
+      case Error(message,_)   => throw new Exception("Error: " + message)
+      case Failure(message,_) => throw new Exception("Failure: " + message)
+    }
+
+}
+
+class FOFProblem(val statements : List[FOFProblemStatement]) {
+  override def toString : String = statements.mkString("\n")
+}
+object FOFProblem {
+  def apply(statements: List[FOFProblemStatement]): FOFProblem = new FOFProblem(statements)
+}
+
+abstract class FOFProblemStatement
+case class AxiomStatement(name : String, formula : E) extends FOFProblemStatement {
+  override def toString : String = "fof("+name + ",axiom," + formula.toString + ")"
+}
+case class ConjectureStatement(name : String, formula : E) extends FOFProblemStatement {
+  override def toString : String = "fof("+name + ",conjecture," + formula.toString + ")"
+}
+case class NegatedConjectureStatement(name : String, formula : E) extends FOFProblemStatement {
+  override def toString : String = "fof("+name + ",negated_conjecture," + formula.toString + ")"
 }

--- a/src/main/scala/at/logic/skeptik/parser/TPTPParsers/ProblemParserFOFTPTP.scala
+++ b/src/main/scala/at/logic/skeptik/parser/TPTPParsers/ProblemParserFOFTPTP.scala
@@ -35,18 +35,13 @@ extends BaseParserTPTP {
 
   def formulaToStatement(name : String, role : String, formula : E) : FOFProblemStatement =
     role match {
-      case "conjecture"         => ConjectureStatement(name,formula)
-      case "negated_conjecture" => NegatedConjectureStatement(name,formula)
-      case _                    => AxiomStatement(name,formula)
+      case "conjecture"         => FOFConjectureStatement(name,formula)
+      case "negated_conjecture" => FOFNegatedConjectureStatement(name,formula)
+      case _                    => FOFAxiomStatement(name,formula)
     }
 
 
-  def problem(fileName : String) : FOFProblem =
-    parse(fileName,problemParser) match {
-      case Success(p,_)       => p
-      case Error(message,_)   => throw new Exception("Error: " + message)
-      case Failure(message,_) => throw new Exception("Failure: " + message)
-    }
+  def problem(fileName : String) : FOFProblem = extract(fileName,problemParser)
 
 }
 
@@ -58,12 +53,12 @@ object FOFProblem {
 }
 
 abstract class FOFProblemStatement
-case class AxiomStatement(name : String, formula : E) extends FOFProblemStatement {
+case class FOFAxiomStatement(name : String, formula : E) extends FOFProblemStatement {
   override def toString : String = "fof("+name + ",axiom," + formula.toString + ")"
 }
-case class ConjectureStatement(name : String, formula : E) extends FOFProblemStatement {
+case class FOFConjectureStatement(name : String, formula : E) extends FOFProblemStatement {
   override def toString : String = "fof("+name + ",conjecture," + formula.toString + ")"
 }
-case class NegatedConjectureStatement(name : String, formula : E) extends FOFProblemStatement {
+case class FOFNegatedConjectureStatement(name : String, formula : E) extends FOFProblemStatement {
   override def toString : String = "fof("+name + ",negated_conjecture," + formula.toString + ")"
 }

--- a/src/main/scala/at/logic/skeptik/parser/TPTPParsers/ProofParserCNFTPTP.scala
+++ b/src/main/scala/at/logic/skeptik/parser/TPTPParsers/ProofParserCNFTPTP.scala
@@ -1,0 +1,77 @@
+package at.logic.skeptik.parser.TPTPParsers
+
+import at.logic.skeptik.judgment.immutable.{SeqSequent => Sequent}
+import at.logic.skeptik.parser.{BaseParserTPTP, ProofParser}
+import at.logic.skeptik.proof.Proof
+import at.logic.skeptik.proof.sequent.{SequentProofNode => Node}
+import at.logic.skeptik.proof.sequent.lk.{Axiom, R, UncheckedInference}
+
+import at.logic.skeptik.parser.TPTPParsers.TPTPAST._
+import at.logic.skeptik.parser.UnexpectedEmptyTPTPFileException
+
+import collection.mutable.{HashMap => MMap}
+
+
+/**
+  * Created by eze on 2016.05.25..
+  */
+object ProofParserCNFTPTP extends ProofParser[Node] with ProofParserCNFTPTP
+
+/**
+  * The ProofParserCNFTPTP trait implements a parser for the CNF fragment of TPTP syntax.
+  * It recognizes only CNF cormulas, with contraction and resolution rules.
+  *
+  * TODO: Add more rules (if needed)
+  *
+  */
+trait ProofParserCNFTPTP
+extends BaseParserTPTP {
+
+
+  private var nodeMap = new MMap[String,Node]
+
+  def reset() : Unit = {nodeMap.clear()}
+
+  //Obtain the actual proof
+  def proof: Parser[Proof[Node]] = TPTP_file ^^ generateProof
+
+  ////////////////////////////////////////////////////////////////////
+  // Proof generation
+  ////////////////////////////////////////////////////////////////////
+  private def generateProof(directives : List[TPTPDirective]) : Proof[Node] = {
+    val expandedDirectives : List[TPTPDirective] = expandIncludes(directives,TPTP_file)
+    if (expandedDirectives.isEmpty) throw new UnexpectedEmptyTPTPFileException
+    else Proof(expandedDirectives.map(prossesDirective).last)
+  }
+
+  private def prossesDirective(directive : TPTPDirective) : Node = {
+    val annotatedFormula : AnnotatedFormula = directive.asInstanceOf[AnnotatedFormula]
+    require(annotatedFormula.language == lexical.CNF.chars)
+    annotatedFormula.annotations match {
+      case None    => annotatedFormulaToAxiom(annotatedFormula)
+      case Some(x) => annotatedFormulaToInference(annotatedFormula)
+    }
+  }
+
+  private def annotatedFormulaToAxiom(annotatedFormula : AnnotatedFormula) : Node = annotatedFormula.formula match {
+    case SimpleSequent(ant,suc) => {
+      val axiom = Axiom(Sequent(ant:_*)(suc:_*))
+      nodeMap += (annotatedFormula.name -> axiom)
+      axiom
+    }
+    case SimpleFormula(formula) => throw new Exception("Not sequent formula detected: " + annotatedFormula.name)
+  }
+
+  private def annotatedFormulaToInference(annotatedFormula : AnnotatedFormula) : Node = ???
+
+  def read(filename: String) : Proof[Node] = {
+    val p : Proof[Node] = parse(filename,proof) match {
+      case Success(p2,_)      => p2
+      case Error(message,_)   => throw new Exception("Error: " + message)
+      case Failure(message,_) => throw new Exception("Failure: " + message)
+    }
+    reset()
+    p
+  }
+}
+

--- a/src/main/scala/at/logic/skeptik/parser/TPTPParsers/ProofParserCNFTPTP.scala
+++ b/src/main/scala/at/logic/skeptik/parser/TPTPParsers/ProofParserCNFTPTP.scala
@@ -114,12 +114,13 @@ extends BaseParserTPTP {
     case _                                    => throw new Exception("Unexpercted format for inference rule.\n Found: "+ term.toString)
   }
   private def extractParents(term : GeneralTerm) : List[String] = {
-    def formarParent(parent : Either[GeneralData,List[GeneralTerm]]) : String = parent match {
-      case Left(GWord(p1)) => p1
+    def formarParent(parent : GeneralTerm) : String = parent match {
+      case GeneralTerm(List(Left(GWord(p1)))) => p1
+      case GeneralTerm(List(Left(GNumber(p1)))) => p1
       case _              => throw new Exception("Unexpected parent format!\nOnly names are allowd.\nFound: "+ parent.toString)
     }
     term match {
-      case GeneralTerm(List(Right(List(GeneralTerm(parentList))))) => parentList map formarParent
+      case GeneralTerm(List(Right(parentList))) => parentList map formarParent
       case _                                        => throw new Exception("Unexpercted format for parents. Only parents name are accepted\n Found: "+ term.toString)
     }
   }

--- a/src/main/scala/at/logic/skeptik/parser/TPTPParsers/ProofParserCNFTPTP.scala
+++ b/src/main/scala/at/logic/skeptik/parser/TPTPParsers/ProofParserCNFTPTP.scala
@@ -48,8 +48,8 @@ extends BaseParserTPTP {
     val annotatedFormula : AnnotatedFormula = directive.asInstanceOf[AnnotatedFormula]
     require(annotatedFormula.language == lexical.CNF.chars)
     annotatedFormula.annotations match {
-      case None    => annotatedFormulaToAxiom(annotatedFormula)
-      case Some(x) => annotatedFormulaToInference(annotatedFormula)
+      case None             => annotatedFormulaToAxiom(annotatedFormula)
+      case Some((source,_)) => annotatedFormulaToNode(annotatedFormula,source)
     }
   }
 
@@ -62,7 +62,21 @@ extends BaseParserTPTP {
     case SimpleFormula(formula) => throw new Exception("Not sequent formula detected: " + annotatedFormula.name)
   }
 
-  private def annotatedFormulaToInference(annotatedFormula : AnnotatedFormula) : Node = ???
+  private def annotatedFormulaToNode(annotatedFormula : AnnotatedFormula, source: Source) : Node = {
+    def getData(term : Either[GeneralData,List[GeneralTerm]]) : Option[List[GeneralTerm]] = term match {
+      case Left(GFunc("inference",list)) => Some(list)
+      case _                             => None
+    }
+    def isAnAxion(records : List[Either[GeneralData,List[GeneralTerm]]]) : Boolean = records.isEmpty
+    val sourceInfo      = source.term
+    val inferenceRecord = sourceInfo.filter(getData(_).nonEmpty)
+    if(isAnAxion(inferenceRecord)) annotatedFormulaToAxiom(annotatedFormula)
+    else {
+      require(inferenceRecord.length == 1)
+      val List(name,_,parents) = getData(inferenceRecord.head).get
+      ???
+    }
+  }
 
   def read(filename: String) : Proof[Node] = {
     val p : Proof[Node] = parse(filename,proof) match {

--- a/src/main/scala/at/logic/skeptik/parser/TPTPParsers/TPTPAST.scala
+++ b/src/main/scala/at/logic/skeptik/parser/TPTPParsers/TPTPAST.scala
@@ -22,15 +22,14 @@ object TPTPAST {
   type FormulaRole = String
   type Annotations = Option[(Source, List[GeneralTerm])]
 
-
-  case class AnnotatedFormula(language: Language, name: Name, role: FormulaRole, formula: RepresentedFormula , annotations: Annotations)
+  abstract class TPTPDirective
+  case class IncludeDirective(fileName : String, selectedFormulas : List[Name])       extends TPTPDirective
+  case class AnnotatedFormula(language: Language, name: Name, role: FormulaRole,
+                              formula: RepresentedFormula , annotations: Annotations) extends TPTPDirective
 
 
   // General purpose things
   type Source = GeneralTerm
-
-  // Include directives
-  type Include = (String, List[Name])
 
   // Non-logical data (GeneralTerm, General data)
   sealed case class GeneralTerm(term: List[Either[GeneralData, List[GeneralTerm]]])

--- a/src/main/scala/at/logic/skeptik/parser/TPTPParsers/TPTPAST.scala
+++ b/src/main/scala/at/logic/skeptik/parser/TPTPParsers/TPTPAST.scala
@@ -1,0 +1,50 @@
+package at.logic.skeptik.parser.TPTPParsers
+
+import at.logic.skeptik.expression.E
+
+/**
+  * TPTP Syntax representation.
+  *
+  * @author Ezequiel Postan
+  * @since 24.05.2016
+  */
+object TPTPAST {
+
+  /*
+   * TODO: Think about let expressions
+   */
+  sealed abstract class RepresentedFormula
+  case class SimpleSequent(ant : Seq[E], suc : Seq[E]) extends RepresentedFormula
+  case class SimpleFormula(formula : E)                extends RepresentedFormula
+
+  type Name        = String
+  type Language    = String
+  type FormulaRole = String
+  type Annotations = Option[(Source, List[GeneralTerm])]
+
+
+  case class AnnotatedFormula(language: Language, name: Name, role: FormulaRole, formula: RepresentedFormula , annotations: Annotations)
+
+
+  // General purpose things
+  type Source = GeneralTerm
+
+  // Include directives
+  type Include = (String, List[Name])
+
+  // Non-logical data (GeneralTerm, General data)
+  sealed case class GeneralTerm(term: List[Either[GeneralData, List[GeneralTerm]]])
+
+  sealed abstract class GeneralData
+  case class GWord(gWord: String)                         extends GeneralData
+  case class GFunc(name: String, args: List[GeneralTerm]) extends GeneralData
+  case class GVar(gVar: String)                           extends GeneralData
+  case class GNumber(gNumber: String)                     extends GeneralData
+  case class GDistinct(data: String)                      extends GeneralData
+  case class GFormulaData(formulaData: FormulaData)       extends GeneralData
+
+  class FormulaData(val language: Language)
+  case class GFormulaDataTerm(override val language: Language, term : E) extends FormulaData(language)
+  case class GFormulaDataFormula(override val language: Language,
+                                 formula : RepresentedFormula)           extends FormulaData(language)
+}

--- a/src/main/scala/at/logic/skeptik/parser/TPTPParsers/TPTPLexical.scala
+++ b/src/main/scala/at/logic/skeptik/parser/TPTPParsers/TPTPLexical.scala
@@ -1,0 +1,129 @@
+package at.logic.skeptik.parser.TPTPParsers
+
+import scala.util.parsing.combinator.lexical.Lexical
+import scala.util.parsing.input.CharArrayReader._
+
+/**
+  * Created by eze on 2016.05.23..
+  */
+class TPTPLexical extends Lexical with TPTPTokens {
+  def token = (
+    singleQuoted
+      | distinctObject
+      | dollarWord
+      | dollarDollarWord
+      | real
+      | rational
+      | integer
+      | upperWord
+      | acceptSeq("include".toList)         ^^^ Include
+      | acceptSeq("fof".toList)             ^^^ FOF
+      | acceptSeq("cnf".toList)             ^^^ CNF
+      | acceptSeq("thf".toList)             ^^^ THF
+      | acceptSeq("tff".toList)             ^^^ TFF
+      | acceptSeq("tpi".toList)             ^^^ TPI
+      | lowerWord
+      | '*'                                 ^^^ Star
+      | '+'                                 ^^^ Plus
+      | '-'                                 ^^^ Minus
+      | '@'                                 ^^^ Application
+      | '^'                                 ^^^ Lambda
+      | '('                                 ^^^ LeftParenthesis
+      | ')'                                 ^^^ RightParenthesis
+      | '['                                 ^^^ LeftBracket
+      | ']'                                 ^^^ RightBracket
+      | ','                                 ^^^ Comma
+      | '.'                                 ^^^ Dot
+      | ':'                                 ^^^ Colon
+      | '?'                                 ^^^ Questionmark
+      // BEGIN The Order of these tokens should not be altered
+      | '<' ~ '=' ~ '>'                     ^^^ Leftrightarrow
+      | '<' ~ '='                           ^^^ Leftarrow
+      | '=' ~ '>'                           ^^^ Rightarrow
+      | '<' ~ '~' ~ '>'                     ^^^ Leftrighttildearrow
+      | '<'                                 ^^^ LessSign
+      | '~' ~ '|'                           ^^^ TildePipe
+      | '~' ~ '&'                           ^^^ TildeAmpersand
+      | '~'                                 ^^^ Tilde
+      | '|'                                 ^^^ VLine
+      | '&'                                 ^^^ Ampersand
+      | '>'                                 ^^^ Arrow
+      | '!' ~ '='                           ^^^ NotEquals
+      | '!'                                 ^^^ Exclamationmark
+      | '='                                 ^^^ Equals
+      // END
+      | EofCh                               ^^^ EOF
+      | failure ("unexcepted character")
+    )
+
+  def whitespace: Parser[Any] = rep(
+    whitespaceChar
+      | '/' ~ '*' ~ commentBlock
+      | '%' ~ rep( chrExcept(EofCh, '\n'))
+      | '/' ~ '*' ~ failure("Lexer error: Unclosed comment block")
+  )
+
+  protected def commentBlock: Parser[Any] = (
+    '*' ~ '/' ^^ { case _ =>' ' }
+      | chrExcept(EofCh) ~ commentBlock
+    )
+
+  def singleQuoted: Parser[SingleQuoted] =
+    '\'' ~ rep1(sqChar) ~ '\'' ^^ {case '\'' ~ content ~ '\'' => SingleQuoted(content.mkString(""))}
+
+  protected def sqChar = (
+    chrExcept('\'', '\\', '\n', EofCh)
+      | '\\' ~ '\'' ^^ { case '\\' ~ '\'' => "'"}
+      | '\\' ~ '\\' ^^ { case '\\' ~ '\\' => "\\"}
+    )
+
+  def distinctObject: Parser[DistinctObject] =
+    '\"' ~ rep(doChar) ~ '\"' ^^ {case '\"' ~ content ~ '\"' => DistinctObject(content.mkString(""))}
+
+  protected def doChar = (
+    chrExcept('\"', '\\', '\n', EofCh)
+      | '\\' ~ '\"' ^^ { case '\\' ~ '\"' => "\""}
+      | '\\' ~ '\\' ^^ { case '\\' ~ '\\' => "\\"}
+    )
+
+  def dollarWord: Parser[DollarWord] = '$' ~ lowerWord ^^ {case '$' ~ word => DollarWord('$' + word.data)}
+  def dollarDollarWord: Parser[DollarDollarWord] = '$' ~ '$' ~ lowerWord ^^ {case '$' ~ '$' ~ word => DollarDollarWord("$$" + word.data)}
+
+
+  def lowerWord: Parser[LowerWord] = elem("lowerword", _.isLower) ~ rep(letter | digit | elem('_')) ^^ {
+    case start ~ rest => LowerWord(start :: rest mkString "")
+  }
+  def upperWord: Parser[UpperWord] = elem("upperword", _.isUpper) ~ rep(letter | digit | elem('_')) ^^ {
+    case start ~ rest => UpperWord(start :: rest mkString "")
+  }
+
+  def integer: Parser[Integer] =
+    opt(elem('+') | elem('-')) ~ unsignedInteger ^^ {
+      case Some('-') ~ i => Integer(-i)
+      case _         ~ i => Integer(i)
+    }
+
+  def unsignedInteger: Parser[Int] = digit ~ rep(digit) ^^ {
+    case d0 ~ ds => (d0 :: ds).mkString("").toInt
+  }
+
+  def rational: Parser[Rational] = opt(elem('+') | elem('-')) ~ unsignedInteger ~ '/' ~ unsignedInteger ^^ {
+    //case _         ~ _ ~ '/' ~ 0 => failure ("Division by zero not allowed")
+    case Some('-') ~ p ~ '/' ~ q => Rational(-p,q)
+    case _         ~ p ~ '/' ~ q => Rational(p,q)
+  }
+
+  def real: Parser[Real] = opt(elem('+') | elem('-')) ~ (exponent ||| fraction) ^^ {
+    case Some('-') ~ v => Real(-v.coeff, v.exp)
+    case _ ~ v => v
+  }
+
+  protected def fraction: Parser[Real] = unsignedInteger ~ '.' ~ digit ~ rep(digit) ^^ {
+    case i ~ '.' ~ d0 ~ ds => Real((i.toString ++ "." ++ (d0 :: ds).mkString("")).toDouble, 1)
+  }
+
+  protected def exponent: Parser[Real] = (unsignedInteger ||| fraction) ~ (elem('E') | elem('e')) ~ integer ^^ {
+    case (i: Int) ~ _ ~ exp => Real(i, exp.value)
+    case (d: Real) ~ _ ~ exp => Real(d.coeff, exp.value)
+  }
+}

--- a/src/main/scala/at/logic/skeptik/parser/TPTPParsers/TPTPTokens.scala
+++ b/src/main/scala/at/logic/skeptik/parser/TPTPParsers/TPTPTokens.scala
@@ -1,0 +1,148 @@
+package at.logic.skeptik.parser.TPTPParsers
+
+import scala.util.parsing.combinator.token.Tokens
+
+/**
+  * Created by eze on 2016.05.23..
+  */
+trait TPTPTokens extends Tokens {
+  case class SingleQuoted(data: String) extends Token {
+    override def chars = "'" + data + "'"
+  }
+  case class DistinctObject(data: String) extends Token {
+    override def chars = "\"" + data + "\""
+  }
+  case class DollarWord(data: String) extends Token {
+    override def chars = data
+  }
+  case class DollarDollarWord(data: String) extends Token {
+    override def chars = data
+  }
+  case class UpperWord(data: String) extends Token {
+    override def chars = data
+  }
+  case class LowerWord(data: String) extends Token {
+    override def chars = data
+  }
+
+  // %----Tokens used in syntax, and cannot be character classes
+  case object VLine extends Token {
+    override def chars = "|"
+  }
+  case object Star extends Token {
+    override def chars = "*"
+  }
+  case object Plus extends Token {
+    override def chars = "+"
+  }
+  case object Minus extends Token {
+    override def chars = "-"
+  }
+  case object Arrow extends Token {
+    override def chars = ">"
+  }
+  case object LessSign extends Token {
+    override def chars = "<"
+  }
+
+  case object Application extends Token {
+    override def chars = "@"
+  }
+  case object Lambda extends Token {
+    override def chars = "^"
+  }
+
+  // Keywords
+  case object FOF extends Token {
+    override def chars = "fof"
+  }
+  case object CNF extends Token {
+    override def chars = "cnf"
+  }
+  case object THF extends Token {
+    override def chars = "thf"
+  }
+  case object TFF extends Token {
+    override def chars = "tff"
+  }
+  case object TPI extends Token {
+    override def chars = "tpi"
+  }
+  case object Include extends Token {
+    override def chars = "include"
+  }
+
+  // Punctuation
+  case object LeftParenthesis extends Token {
+    override def chars = "("
+  }
+  case object RightParenthesis extends Token {
+    override def chars = ")"
+  }
+  case object LeftBracket extends Token {
+    override def chars = "["
+  }
+  case object RightBracket extends Token {
+    override def chars = "]"
+  }
+  case object Comma extends Token {
+    override def chars = ","
+  }
+  case object Dot extends Token {
+    override def chars = "."
+  }
+  case object Colon extends Token {
+    override def chars = ":"
+  }
+
+  // Operators
+  case object Exclamationmark extends Token {
+    override def chars = "!"
+  }
+  case object Questionmark extends Token {
+    override def chars = "?"
+  }
+  case object Tilde extends Token {
+    override def chars = "~"
+  }
+  case object Ampersand extends Token {
+    override def chars = "&"
+  }
+  case object Leftrightarrow extends Token {
+    override def chars = "<=>"
+  }
+  case object Rightarrow extends Token {
+    override def chars = "=>"
+  }
+  case object Leftarrow extends Token {
+    override def chars = "<="
+  }
+  case object Leftrighttildearrow extends Token {
+    override def chars = "<~>"
+  }
+  case object TildePipe extends Token {
+    override def chars = "~|"
+  }
+  case object TildeAmpersand extends Token {
+    override def chars = "~&"
+  }
+
+  // Predicates
+  case object Equals extends Token {
+    override def chars = "="
+  }
+  case object NotEquals extends Token {
+    override def chars = "!="
+  }
+
+  // %----Numbers. Signs are made part of the same token here.
+  case class Real(coeff: Double, exp: Int) extends Token {
+    override def chars = coeff.toString + "e" + exp.toString
+  }
+  case class Rational(p: Int, q: Int) extends Token {
+    override def chars = p.toString + "/" + q.toString
+  }
+  case class Integer(value: Int) extends Token {
+    override def chars = value.toString
+  }
+}

--- a/src/test/scala/at/logic/skeptik/parser/TPTPTest.scala
+++ b/src/test/scala/at/logic/skeptik/parser/TPTPTest.scala
@@ -2,7 +2,7 @@ package at.logic.skeptik.parser
 
 object TPTPTest {
   def main(args: Array[String]):Unit = {
-    val proof = ParserTPTP.read("examples/proofs/SPASS/C(3_3)_attempted_instantiation.tptp")
+    val proof = ProofParserTPTP.read("examples/proofs/SPASS/C(3_3)_attempted_instantiation.tptp")
     println(proof)
   }
 }

--- a/src/test/scala/at/logic/skeptik/parser/TPTPTest.scala
+++ b/src/test/scala/at/logic/skeptik/parser/TPTPTest.scala
@@ -1,8 +1,13 @@
 package at.logic.skeptik.parser
 
+import at.logic.skeptik.parser.TPTPParsers.{ProblemParserCNFTPTP, ProblemParserFOFTPTP}
+
 object TPTPTest {
   def main(args: Array[String]):Unit = {
-    val proof = ProofParserTPTP.read("examples/proofs/SPASS/C(3_3)_attempted_instantiation.tptp")
-    println(proof)
+    val problem1 = ProblemParserCNFTPTP.problem("examples/problems/CNF/CNF.cnfp")
+    println(problem1)
+    println("\n\n\n")
+    val problem2 = ProblemParserFOFTPTP.problem("examples/problems/FOF/FOF.fofp")
+    println(problem2)
   }
 }


### PR DESCRIPTION
Implementation of parsers for FOF and CNF languages.
Two problem parsers were also implemented using the parsers mentioned before as a library, one for FOF problems and another for CNF problems. 
A proof of concept for CNF proofs parsers was implemented too. It currently supports resolution proofs generated by the E theorem prover using only the "sr" rule of that system. This parser will be refactored in order to handle more rules and the current code will be refactored too to keep it generic over the rules of the system using the TPTP syntax
