### PR TITLE
Hotfix - missing variables set added to TPTP parsers

### DIFF
--- a/examples/proofs/TPTP/complexCNF.tptp
+++ b/examples/proofs/TPTP/complexCNF.tptp
@@ -1,0 +1,9 @@
+cnf(c_0_0, axiom, (q|~p(X1)), file('../../../test.tptp', 1)).
+cnf(c_0_1, axiom, (~q), file('../../../test.tptp', 3)).
+cnf(c_0_2, axiom, (r(c)|~s(d)), file('../../../test.tptp', 4)).
+cnf(c_0_3, axiom, (~r(c)), file('../../../test.tptp', 5)).
+cnf(c_0_4, axiom, (p(a)|s(X1)), file('../../../test.tptp', 2)).
+cnf(c_0_5, plain, (~p(X1)), inference(sr,[status(thm)],[c_0_0, c_0_1])).
+%cnf(c_0_6, plain, (~s(d)), inference(sr,[status(thm)],[c_0_2, c_0_3])).
+cnf(c_0_7, plain, (s(X1)), inference(sr,[status(thm)],[c_0_4, c_0_5])).
+cnf(c_0_8, plain, ($false),inference(sr,[status(thm)],[inference(sr,[status(thm)],[c_0_2, c_0_3]),c_0_7])).

--- a/src/main/scala/at/logic/skeptik/parser/ParserTPTP.scala
+++ b/src/main/scala/at/logic/skeptik/parser/ParserTPTP.scala
@@ -49,7 +49,7 @@ extends TokenParsers with PackratParsers {
    */
   private var varSet : Set[Var] = new MSet[Var]()
   private def recordVar(v : String) {varSet += new Var(v,i)}
-  def getSeenVars : Set[Var] = varSet
+  def getSeenVars : Set[Var] = varSet.clone()
   def resetVarsSeen() : Unit = { varSet.clear() }
 
   val  lexical = new TPTPLexical

--- a/src/main/scala/at/logic/skeptik/parser/TPTPParsers/ProblemParserCNFTPTP.scala
+++ b/src/main/scala/at/logic/skeptik/parser/TPTPParsers/ProblemParserCNFTPTP.scala
@@ -1,9 +1,10 @@
 package at.logic.skeptik.parser.TPTPParsers
 
-import at.logic.skeptik.expression.E
+import at.logic.skeptik.expression.{E, Var}
 import at.logic.skeptik.parser.BaseParserTPTP
 import at.logic.skeptik.parser.TPTPParsers.TPTPAST.{AnnotatedFormula, SimpleSequent, TPTPDirective}
 
+import collection.mutable.Set
 /**
   * @author  Ezequiel Postan
   * @since   24.05.2016
@@ -30,7 +31,7 @@ extends BaseParserTPTP {
     val expandedDirectives : List[TPTPDirective]         = expandIncludes(directives,TPTP_file)
     val formulas   : List[(String,String,Seq[E],Seq[E])] = expandedDirectives map extractFormulas
     val statements : List[CNFProblemStatement]           = formulas map ((t : (String,String,Seq[E],Seq[E])) => formulaToStatement(t._1,t._2,t._3,t._4))
-    CNFProblem(statements)
+    CNFProblem(statements,getSeenVars)
   }
 
 
@@ -52,11 +53,11 @@ extends BaseParserTPTP {
 
 }
 
-class CNFProblem(val statements : List[CNFProblemStatement]) {
-  override def toString : String = statements.mkString("\n")
+class CNFProblem(val statements : List[CNFProblemStatement],val variables : Set[Var]) {
+  override def toString : String = statements.mkString("\n") + "\nVariables: " + variables.mkString(",")
 }
 object CNFProblem {
-  def apply(statements: List[CNFProblemStatement]): CNFProblem = new CNFProblem(statements)
+  def apply(statements: List[CNFProblemStatement], variables : Set[Var]): CNFProblem = new CNFProblem(statements,variables)
 }
 
 abstract class CNFProblemStatement

--- a/src/main/scala/at/logic/skeptik/parser/TPTPParsers/ProblemParserFOFTPTP.scala
+++ b/src/main/scala/at/logic/skeptik/parser/TPTPParsers/ProblemParserFOFTPTP.scala
@@ -1,9 +1,10 @@
 package at.logic.skeptik.parser.TPTPParsers
 
-import at.logic.skeptik.expression.E
+import at.logic.skeptik.expression.{E, Var}
 import at.logic.skeptik.parser.BaseParserTPTP
 import at.logic.skeptik.parser.TPTPParsers.TPTPAST.{AnnotatedFormula, SimpleFormula, TPTPDirective}
 
+import collection.mutable.Set
 /**
   * Created by eze on 2016.05.25..
   */
@@ -23,7 +24,7 @@ extends BaseParserTPTP {
     val expandedDirectives : List[TPTPDirective] = expandIncludes(directives,TPTP_file)
     val formulas   : List[(String,String,E)]     = expandedDirectives map extractFormulas
     val statements : List[FOFProblemStatement]   = formulas map ((t : (String,String,E)) => formulaToStatement(t._1,t._2,t._3))
-    FOFProblem(statements)
+    FOFProblem(statements,getSeenVars)
   }
 
 
@@ -45,11 +46,11 @@ extends BaseParserTPTP {
 
 }
 
-class FOFProblem(val statements : List[FOFProblemStatement]) {
-  override def toString : String = statements.mkString("\n")
+class FOFProblem(val statements : List[FOFProblemStatement], val variables : Set[Var]) {
+  override def toString : String = statements.mkString("\n") + "\nVariables: " + variables.mkString(",")
 }
 object FOFProblem {
-  def apply(statements: List[FOFProblemStatement]): FOFProblem = new FOFProblem(statements)
+  def apply(statements: List[FOFProblemStatement],variables : Set[Var]): FOFProblem = new FOFProblem(statements,variables)
 }
 
 abstract class FOFProblemStatement

--- a/src/test/scala/at/logic/skeptik/parser/TPTPTest.scala
+++ b/src/test/scala/at/logic/skeptik/parser/TPTPTest.scala
@@ -1,13 +1,19 @@
 package at.logic.skeptik.parser
 
-import at.logic.skeptik.parser.TPTPParsers.{ProblemParserCNFTPTP, ProblemParserFOFTPTP}
+import at.logic.skeptik.parser.TPTPParsers.{ProblemParserCNFTPTP, ProblemParserFOFTPTP, ProofParserCNFTPTP}
 
 object TPTPTest {
   def main(args: Array[String]):Unit = {
     val problem1 = ProblemParserCNFTPTP.problem("examples/problems/CNF/CNF.cnfp")
     println(problem1)
+    ProblemParserCNFTPTP.resetVarsSeen()
     println("\n\n\n")
     val problem2 = ProblemParserFOFTPTP.problem("examples/problems/FOF/FOF.fofp")
     println(problem2)
+    ProblemParserFOFTPTP.resetVarsSeen()
+    println("\n\n\n")
+    val proof1 = ProofParserCNFTPTP.read("examples/proofs/TPTP/complexCNF.tptp")
+    println(proof1)
+    println(ProofParserCNFTPTP.getVariables)
   }
 }


### PR DESCRIPTION
I added the missing variables sets that where missed in the last pull request
