### PR TITLE
Splitting Algorithm - Version 1.0

### DIFF
--- a/examples/proofs/TPTP/FOSplitToCompress.tptp
+++ b/examples/proofs/TPTP/FOSplitToCompress.tptp
@@ -1,0 +1,23 @@
+cnf(c_0_0, axiom, ~q(X) ).
+cnf(c_0_1, axiom, q(f(X,b)) | p(X) | r).
+cnf(c_0_2, axiom, q(f(R,Y)) | ~p(X)).
+cnf(c_0_3, axiom, q(f(a,W)) | ~r).
+cnf(c_0_4, plain, ~p(Y) , inference(sr,[status(thm)],[c_0_0, c_0_2])).
+cnf(c_0_5, plain, ~r , inference(sr,[status(thm)],[c_0_0, c_0_3])).
+cnf(c_0_6, plain, p(H) | r , inference(sr,[status(thm)],[c_0_0, c_0_1])).
+cnf(c_0_7, plain, p(X) , inference(sr,[status(thm)],[c_0_5, c_0_6])).
+cnf(c_0_8, plain, ($false),inference(sr,[status(thm)],[c_0_4, c_0_7])).
+
+/*
+This one does not pass. Change ~p(Y) for ~p(X) in c_0_3 and it will pass.
+
+cnf(c_0_0, axiom, ~q(X) ).
+cnf(c_0_1, axiom, q(f(X,b)) | p(a) | r).
+cnf(c_0_2, axiom, q(f(R,Y)) | ~p(Y)).
+cnf(c_0_3, axiom, q(f(a,W)) | ~r).
+cnf(c_0_4, plain, ~p(Y) , inference(sr,[status(thm)],[c_0_0, c_0_2])).
+cnf(c_0_5, plain, ~r , inference(sr,[status(thm)],[c_0_0, c_0_3])).
+cnf(c_0_6, plain, p(a) | r , inference(sr,[status(thm)],[c_0_0, c_0_1])).
+cnf(c_0_7, plain, p(a) , inference(sr,[status(thm)],[c_0_5, c_0_6])).
+cnf(c_0_8, plain, ($false),inference(sr,[status(thm)],[c_0_4, c_0_7])).
+*/

--- a/examples/proofs/TPTP/FOSplitToCompress.tptp
+++ b/examples/proofs/TPTP/FOSplitToCompress.tptp
@@ -1,3 +1,21 @@
+/*
+  This case should be compressed by all heuristics
+*/
+
+cnf(c_0_0, axiom, ~q(X) ).
+cnf(c_0_1, axiom, q(f(X,b)) | p(X) | r).
+cnf(c_0_2, axiom, q(f(R,Y)) | ~p(X)).
+cnf(c_0_3, axiom, q(f(a,W)) | ~r).
+cnf(c_0_4, plain, ~p(X) , inference(sr,[status(thm)],[c_0_0, c_0_2])).
+cnf(c_0_5, plain, ~r , inference(sr,[status(thm)],[c_0_0, c_0_3])).
+cnf(c_0_6, plain, p(X) | r , inference(sr,[status(thm)],[c_0_0, c_0_1])).
+cnf(c_0_7, plain, p(X) , inference(sr,[status(thm)],[c_0_5, c_0_6])).
+cnf(c_0_8, plain, ($false),inference(sr,[status(thm)],[c_0_4, c_0_7])).
+
+
+/*
+This is an extrange bug
+
 cnf(c_0_0, axiom, ~q(X) ).
 cnf(c_0_1, axiom, q(f(X,b)) | p(X) | r).
 cnf(c_0_2, axiom, q(f(R,Y)) | ~p(Y)).
@@ -8,7 +26,7 @@ cnf(c_0_6, plain, p(X) | r , inference(sr,[status(thm)],[c_0_0, c_0_1])).
 cnf(c_0_7, plain, p(X) , inference(sr,[status(thm)],[c_0_5, c_0_6])).
 cnf(c_0_8, plain, ($false),inference(sr,[status(thm)],[c_0_4, c_0_7])).
 
-/*
+
 The representation of this proof is:
 
                                    ¬r,q(f(a,W))    2     q(f(X,b)),p(X),r    2

--- a/examples/proofs/TPTP/FOSplitToCompress.tptp
+++ b/examples/proofs/TPTP/FOSplitToCompress.tptp
@@ -1,7 +1,6 @@
 /*
   This case should be compressed by all heuristics
 */
-
 cnf(c_0_0, axiom, ~q(X) ).
 cnf(c_0_1, axiom, q(f(X,b)) | p(X) | r).
 cnf(c_0_2, axiom, q(f(R,Y)) | ~p(X)).

--- a/examples/proofs/TPTP/FOSplitToCompress.tptp
+++ b/examples/proofs/TPTP/FOSplitToCompress.tptp
@@ -1,15 +1,63 @@
 cnf(c_0_0, axiom, ~q(X) ).
 cnf(c_0_1, axiom, q(f(X,b)) | p(X) | r).
-cnf(c_0_2, axiom, q(f(R,Y)) | ~p(X)).
+cnf(c_0_2, axiom, q(f(R,Y)) | ~p(Y)).
 cnf(c_0_3, axiom, q(f(a,W)) | ~r).
 cnf(c_0_4, plain, ~p(Y) , inference(sr,[status(thm)],[c_0_0, c_0_2])).
 cnf(c_0_5, plain, ~r , inference(sr,[status(thm)],[c_0_0, c_0_3])).
-cnf(c_0_6, plain, p(H) | r , inference(sr,[status(thm)],[c_0_0, c_0_1])).
+cnf(c_0_6, plain, p(X) | r , inference(sr,[status(thm)],[c_0_0, c_0_1])).
 cnf(c_0_7, plain, p(X) , inference(sr,[status(thm)],[c_0_5, c_0_6])).
 cnf(c_0_8, plain, ($false),inference(sr,[status(thm)],[c_0_4, c_0_7])).
 
 /*
-This one does not pass. Change ~p(Y) for ~p(X) in c_0_3 and it will pass.
+The representation of this proof is:
+
+                                   ¬r,q(f(a,W))    2     q(f(X,b)),p(X),r    2
+                                   -----------------    -----------------------
+ ¬p(Y),q(f(R,Y))  2: ¬q(X)                  ¬ r                 r, p(R)
+ -------------------------                 -----------------------------
+          ¬p(Y)                                       p(R)
+          ------------------------------------------------
+                                   {}
+
+The output is:
+
+1: { ⊢ (q (f X b)), (p X), r}   : Axiom()[]
+2: {(q X) ⊢ }   : Axiom()[]
+3: { ⊢ r, (p R)}        : UnifyingResolution(1, 2)[]
+4: {r ⊢ (q (f a W))}    : Axiom()[]
+5: {r ⊢ }       : UnifyingResolution(4, 2)[]
+6: { ⊢ (p R)}   : UnifyingResolution(3, 5)[]
+7: {(p Y) ⊢ (q (f R Y))}        : Axiom()[]
+8: {(p Y) ⊢ }   : UnifyingResolution(7, 2)[]
+9: { ⊢ }        : UnifyingResolution(6, 8)[]
+
+And then an exception, you can see this running the test written here in
+
+Skeptik/src/main/scala/at/logic/skeptik/algorithm/compressor/FOSplit/FOCottonSplit.scala
+
+The conclusions of the two proofs obtained applying the splitting procedure are:
+   ⊢ (q (f Y b)), (q (f a W)), (q (f R Y))
+
+and
+
+  (q X) ⊢
+
+This is something I don't get, because the occurrences of the literal q shouldn't share variables because they come from
+different clauses.
+
+Is this a bug?
+
+*/
+
+
+
+
+
+
+/*
+On the other hand this one does not pass and is a problem with the heuristic that let you split a node that shouldn't be
+splittend.
+Change ~p(Y) for ~p(X) in c_0_3 and it will pass.
 
 cnf(c_0_0, axiom, ~q(X) ).
 cnf(c_0_1, axiom, q(f(X,b)) | p(a) | r).

--- a/examples/proofs/TPTP/simplestSplit.tptp
+++ b/examples/proofs/TPTP/simplestSplit.tptp
@@ -1,0 +1,15 @@
+cnf(c_0_0, axiom, ~q ).
+cnf(c_0_1, axiom, q | p).
+cnf(c_0_2, axiom, ~p).
+cnf(c_0_3, plain, q ,inference(sr,[status(thm)],[c_0_1, c_0_2])).
+cnf(c_0_4, plain, ($false),inference(sr,[status(thm)],[c_0_0, c_0_3])).
+
+
+/*
+cnf(c_0_0, axiom, q  | ~p(X1)).
+cnf(c_0_1, axiom, ~q ).
+cnf(c_0_2, axiom, q | p(Y1)).
+cnf(c_0_4, plain, p(Y1), inference(sr,[status(thm)],[c_0_1, c_0_2])).
+cnf(c_0_5, plain, q, inference(sr,[status(thm)],[c_0_0, c_0_4])).
+%cnf(c_0_6, plain, ($false),inference(sr,[status(thm)],[c_0_1, c_0_5])).
+*/

--- a/examples/proofs/TPTP/splitTest.tptp
+++ b/examples/proofs/TPTP/splitTest.tptp
@@ -1,0 +1,6 @@
+cnf(c_0_0, axiom, q  | ~p(X1)).
+cnf(c_0_1, axiom, ~q ).
+cnf(c_0_2, axiom, q | p(Y1)).
+cnf(c_0_3, plain, ~p(X1), inference(sr,[status(thm)],[c_0_0, c_0_1])).
+cnf(c_0_4, plain, p(Y1), inference(sr,[status(thm)],[c_0_1, c_0_2])).
+cnf(c_0_5, plain, ($false),inference(sr,[status(thm)],[c_0_3, c_0_4])).

--- a/examples/proofs/TPTP/splitTest.tptp
+++ b/examples/proofs/TPTP/splitTest.tptp
@@ -3,4 +3,14 @@ cnf(c_0_1, axiom, ~q ).
 cnf(c_0_2, axiom, q | p(Y1)).
 cnf(c_0_3, plain, ~p(X1), inference(sr,[status(thm)],[c_0_0, c_0_1])).
 cnf(c_0_4, plain, p(Y1), inference(sr,[status(thm)],[c_0_1, c_0_2])).
+cnf(c_0_5, plain, q, inference(sr,[status(thm)],[c_0_0, c_0_4])).
+cnf(c_0_6, plain, ($false),inference(sr,[status(thm)],[c_0_1, c_0_5])).
+
+/*
+cnf(c_0_0, axiom, q  | ~p(X1)).
+cnf(c_0_1, axiom, ~q ).
+cnf(c_0_2, axiom, q | p(Y1)).
+cnf(c_0_3, plain, ~p(X1), inference(sr,[status(thm)],[c_0_0, c_0_1])).
+cnf(c_0_4, plain, p(Y1), inference(sr,[status(thm)],[c_0_1, c_0_2])).
 cnf(c_0_5, plain, ($false),inference(sr,[status(thm)],[c_0_3, c_0_4])).
+*/

--- a/examples/proofs/TPTP/splitTest2.tptp
+++ b/examples/proofs/TPTP/splitTest2.tptp
@@ -3,4 +3,6 @@ cnf(c_0_1, axiom, ~q ).
 cnf(c_0_2, axiom, q | p(Y1)).
 cnf(c_0_3, plain, ~p(X1), inference(sr,[status(thm)],[c_0_0, c_0_1])).
 cnf(c_0_4, plain, p(Y1), inference(sr,[status(thm)],[c_0_1, c_0_2])).
-cnf(c_0_5, plain, ($false),inference(sr,[status(thm)],[c_0_3, c_0_4])).
+cnf(c_0_5, plain, q, inference(sr,[status(thm)],[c_0_0, c_0_4])).
+cnf(c_0_6, plain, ($false),inference(sr,[status(thm)],[c_0_1, c_0_5])).
+

--- a/examples/proofs/TPTP/splitToCompress.tptp
+++ b/examples/proofs/TPTP/splitToCompress.tptp
@@ -1,0 +1,9 @@
+cnf(c_0_0, axiom, ~q ).
+cnf(c_0_1, axiom, q | p | r).
+cnf(c_0_2, axiom, q | ~p).
+cnf(c_0_3, axiom, q | ~r).
+cnf(c_0_4, plain, ~p , inference(sr,[status(thm)],[c_0_0, c_0_2])).
+cnf(c_0_5, plain, ~r , inference(sr,[status(thm)],[c_0_0, c_0_3])).
+cnf(c_0_6, plain, p | r , inference(sr,[status(thm)],[c_0_0, c_0_1])).
+cnf(c_0_7, plain, p , inference(sr,[status(thm)],[c_0_5, c_0_6])).
+cnf(c_0_8, plain, ($false),inference(sr,[status(thm)],[c_0_4, c_0_7])).

--- a/src/main/scala/at/logic/skeptik/algorithm/compressor/FOSplit/FOCottonSplit.scala
+++ b/src/main/scala/at/logic/skeptik/algorithm/compressor/FOSplit/FOCottonSplit.scala
@@ -26,6 +26,6 @@ object FOCottonSplitTest {
   */
 class FOCottonSplit(override val variables : MSet[Var], val timeout: Int)
 extends FOSplit(variables) with FOAdditivityHeuristic with FORandomChoice with Timeout
-  //with SetContentionHeuristic with NameEquality
+  with SetContentionHeuristic with NameEquality
   //with SeenLiteralsHeuristic with NameEquality
-  with SetContentionAndSeenLiteralsHeuristic with NameEquality
+  //with SetContentionAndSeenLiteralsHeuristic with NameEquality

--- a/src/main/scala/at/logic/skeptik/algorithm/compressor/FOSplit/FOCottonSplit.scala
+++ b/src/main/scala/at/logic/skeptik/algorithm/compressor/FOSplit/FOCottonSplit.scala
@@ -9,14 +9,14 @@ import scala.collection.mutable.{Set => MSet}
 
 object FOCottonSplitTest {
   def main(args: Array[String]): Unit = {
-    val proof = ProofParserCNFTPTP.read("examples/proofs/TPTP/splitTest.tptp")
+    val proof = ProofParserCNFTPTP.read("examples/proofs/TPTP/splitTest2.tptp")
     val variables = ProofParserCNFTPTP.getVariables
     println("Original Proof:")
     print("Variables: ")
     println(variables.mkString(","))
     println("Proof:")
     println(proof)
-    val split = new FOCottonSplit(variables, 100)
+    val split = new FOCottonSplit(variables, 10000)
     println(split(proof))
   }
 }

--- a/src/main/scala/at/logic/skeptik/algorithm/compressor/FOSplit/FOCottonSplit.scala
+++ b/src/main/scala/at/logic/skeptik/algorithm/compressor/FOSplit/FOCottonSplit.scala
@@ -25,4 +25,7 @@ object FOCottonSplitTest {
   * Created by eze on 2016.06.14..
   */
 class FOCottonSplit(override val variables : MSet[Var], val timeout: Int)
-extends FOSplit(variables) with FOAdditivityHeuristic with FORandomChoice with Timeout with SeenLiteralsHeuristic with NameEquality
+extends FOSplit(variables) with FOAdditivityHeuristic with FORandomChoice with Timeout
+  with SetContentionHeuristic with NameEquality
+  //with SeenLiteralsHeuristic with NameEquality
+  //with SetContentionAndSeenLiteralsHeuristic with NameEquality

--- a/src/main/scala/at/logic/skeptik/algorithm/compressor/FOSplit/FOCottonSplit.scala
+++ b/src/main/scala/at/logic/skeptik/algorithm/compressor/FOSplit/FOCottonSplit.scala
@@ -1,0 +1,28 @@
+package at.logic.skeptik.algorithm.compressor.FOSplit
+
+import at.logic.skeptik.algorithm.compressor.Timeout
+import at.logic.skeptik.expression.Var
+import at.logic.skeptik.parser.TPTPParsers.ProofParserCNFTPTP
+
+import scala.collection.mutable.{Set => MSet}
+
+
+object FOCottonSplitTest {
+  def main(args: Array[String]): Unit = {
+    val proof = ProofParserCNFTPTP.read("examples/proofs/TPTP/splitTest.tptp")
+    val variables = ProofParserCNFTPTP.getVariables
+    println("Original Proof:")
+    print("Variables: ")
+    println(variables.mkString(","))
+    println("Proof:")
+    println(proof)
+    val split = new FOCottonSplit(variables, 100)
+    println(split(proof))
+  }
+}
+
+/**
+  * Created by eze on 2016.06.14..
+  */
+class FOCottonSplit(override val variables : MSet[Var], val timeout: Int)
+extends FOSplit(variables) with FOAdditivityHeuristic with FORandomChoice with Timeout with SeenLiteralsHeuristic with NameEquality

--- a/src/main/scala/at/logic/skeptik/algorithm/compressor/FOSplit/FOCottonSplit.scala
+++ b/src/main/scala/at/logic/skeptik/algorithm/compressor/FOSplit/FOCottonSplit.scala
@@ -16,7 +16,7 @@ object FOCottonSplitTest {
     println(variables.mkString(","))
     println("Proof:")
     println(proof)
-    val split = new FOCottonSplit(variables, 1000)
+    val split = new FOCottonSplit(variables, 100)
     println(split(proof))
   }
 }
@@ -26,6 +26,6 @@ object FOCottonSplitTest {
   */
 class FOCottonSplit(override val variables : MSet[Var], val timeout: Int)
 extends FOSplit(variables) with FOAdditivityHeuristic with FORandomChoice with Timeout
-  with SetContentionHeuristic with NameEquality
+  //with SetContentionHeuristic with NameEquality
   //with SeenLiteralsHeuristic with NameEquality
-  //with SetContentionAndSeenLiteralsHeuristic with NameEquality
+  with SetContentionAndSeenLiteralsHeuristic with NameEquality

--- a/src/main/scala/at/logic/skeptik/algorithm/compressor/FOSplit/FOCottonSplit.scala
+++ b/src/main/scala/at/logic/skeptik/algorithm/compressor/FOSplit/FOCottonSplit.scala
@@ -9,14 +9,14 @@ import scala.collection.mutable.{Set => MSet}
 
 object FOCottonSplitTest {
   def main(args: Array[String]): Unit = {
-    val proof = ProofParserCNFTPTP.read("examples/proofs/TPTP/splitTest2.tptp")
+    val proof = ProofParserCNFTPTP.read("examples/proofs/TPTP/FOSplitToCompress.tptp")
     val variables = ProofParserCNFTPTP.getVariables
     println("Original Proof:")
     print("Variables: ")
     println(variables.mkString(","))
     println("Proof:")
     println(proof)
-    val split = new FOCottonSplit(variables, 10000)
+    val split = new FOCottonSplit(variables, 1000)
     println(split(proof))
   }
 }

--- a/src/main/scala/at/logic/skeptik/algorithm/compressor/FOSplit/FOCottonSplit.scala
+++ b/src/main/scala/at/logic/skeptik/algorithm/compressor/FOSplit/FOCottonSplit.scala
@@ -9,23 +9,25 @@ import scala.collection.mutable.{Set => MSet}
 
 object FOCottonSplitTest {
   def main(args: Array[String]): Unit = {
-    val proof = ProofParserCNFTPTP.read("examples/proofs/TPTP/FOSplitToCompress.tptp")
+    val proof     = ProofParserCNFTPTP.read("examples/proofs/TPTP/FOSplitToCompress.tptp")
     val variables = ProofParserCNFTPTP.getVariables
+    val split     = new FOCottonSplit(variables, 100)
     println("Original Proof:")
     print("Variables: ")
     println(variables.mkString(","))
     println("Proof:")
     println(proof)
-    val split = new FOCottonSplit(variables, 100)
     println(split(proof))
   }
 }
 
 /**
-  * Created by eze on 2016.06.14..
+  * The class FOCottonSplit represent a first order generalization of
+  * Cotton's splitting algorithm.
+  *
+  * @param variables The set of variables that appear in the proof
+  * @param timeout   A timeout parameter to stop the iterative splitting steps
   */
 class FOCottonSplit(override val variables : MSet[Var], val timeout: Int)
 extends FOSplit(variables) with FOAdditivityHeuristic with FORandomChoice with Timeout
-  with SetContentionHeuristic with NameEquality
-  //with SeenLiteralsHeuristic with NameEquality
-  //with SetContentionAndSeenLiteralsHeuristic with NameEquality
+  with SetContentionAndSeenLiteralsHeuristic with NameEquality

--- a/src/main/scala/at/logic/skeptik/algorithm/compressor/FOSplit/FORandomChoice.scala
+++ b/src/main/scala/at/logic/skeptik/algorithm/compressor/FOSplit/FORandomChoice.scala
@@ -1,0 +1,30 @@
+package at.logic.skeptik.algorithm.compressor.FOSplit
+
+import at.logic.skeptik.expression.E
+import at.logic.skeptik.expression.formula.Atom
+
+/**
+  * Created by eze on 2016.06.14..
+  */
+trait FORandomChoice extends AbstractFOSplitHeuristic {
+  private val rand = new scala.util.Random()
+
+  private def randomLong(max: Long):Long = {
+    if (max <= Int.MaxValue.toLong)
+      rand.nextInt(max.toInt)
+    else {
+      var draw = rand.nextLong()
+      if (draw < 0) draw = -draw
+      if (draw < max) draw else ((draw - max).toDouble * max.toDouble / (Long.MaxValue - max).toDouble).toLong
+    }
+  }
+
+  def chooseVariable(literalAdditivity: collection.Map[String,Long], totalAdditivity: Long) = {
+    val iterator = literalAdditivity.toIterator
+    def searchPos(left: Long): E = {
+      val next = iterator.next
+      if (next._2 < left && iterator.hasNext) searchPos(left - next._2) else Atom(next._1,Nil)
+    }
+    searchPos(randomLong(totalAdditivity) + 1)
+  }
+}

--- a/src/main/scala/at/logic/skeptik/algorithm/compressor/FOSplit/FORandomChoice.scala
+++ b/src/main/scala/at/logic/skeptik/algorithm/compressor/FOSplit/FORandomChoice.scala
@@ -4,7 +4,8 @@ import at.logic.skeptik.expression.E
 import at.logic.skeptik.expression.formula.Atom
 
 /**
-  * Created by eze on 2016.06.14..
+  * Tha trait FORandomChoice implement a random choice for the
+  * literals to use to split the proof.
   */
 trait FORandomChoice extends AbstractFOSplitHeuristic {
   private val rand = new scala.util.Random()

--- a/src/main/scala/at/logic/skeptik/algorithm/compressor/FOSplit/FORandomChoice.scala
+++ b/src/main/scala/at/logic/skeptik/algorithm/compressor/FOSplit/FORandomChoice.scala
@@ -21,9 +21,12 @@ trait FORandomChoice extends AbstractFOSplitHeuristic {
 
   def chooseVariable(literalAdditivity: collection.Map[String,Long], totalAdditivity: Long) = {
     val iterator = literalAdditivity.toIterator
-    def searchPos(left: Long): E = {
-      val next = iterator.next
-      if (next._2 < left && iterator.hasNext) searchPos(left - next._2) else Atom(next._1,Nil)
+    def searchPos(left: Long): Option[E] = {
+      if(iterator.isEmpty) None
+      else {
+        val next = iterator.next
+        if (next._2 < left && iterator.hasNext) searchPos(left - next._2) else Some(Atom(next._1, Nil))
+      }
     }
     searchPos(randomLong(totalAdditivity) + 1)
   }

--- a/src/main/scala/at/logic/skeptik/algorithm/compressor/FOSplit/FOSplit.scala
+++ b/src/main/scala/at/logic/skeptik/algorithm/compressor/FOSplit/FOSplit.scala
@@ -137,6 +137,9 @@ abstract class FOSplit(val variables : MSet[Var]) extends (Proof[Node] => Proof[
       val leftContracted = Contraction.contractIfPossible(left, variables)
       val rightContracted = Contraction.contractIfPossible(right, variables)
       val compressedProof: Proof[Node] = UnifyingResolution.resolve(leftContracted, rightContracted, variables)
+      //println("PROOF AFTER SPLIT")
+      //println(compressedProof)
+      //println("SIZE: " + compressedProof.size + "ORIGINAL WAS "+p.size)
       if (countResolutionNodes(compressedProof) < countResolutionNodes(p)) compressedProof else p
     }
   }

--- a/src/main/scala/at/logic/skeptik/algorithm/compressor/FOSplit/FOSplit.scala
+++ b/src/main/scala/at/logic/skeptik/algorithm/compressor/FOSplit/FOSplit.scala
@@ -1,0 +1,98 @@
+package at.logic.skeptik.algorithm.compressor.FOSplit
+
+import at.logic.skeptik.algorithm.compressor.FOSplit.equalities.NameEquality
+import at.logic.skeptik.expression.formula.Atom
+import at.logic.skeptik.expression.{E, Var}
+import at.logic.skeptik.judgment.immutable.SeqSequent
+import at.logic.skeptik.parser.TPTPParsers.ProofParserCNFTPTP
+import at.logic.skeptik.proof.Proof
+import at.logic.skeptik.proof.sequent.lk.Axiom
+import at.logic.skeptik.proof.sequent.resolution.{Contraction, UnifyingResolution}
+import at.logic.skeptik.proof.sequent.{SequentProofNode => Node}
+
+import collection.mutable.{Set => MSet}
+
+object FOSplitTest {
+  def main(args: Array[String]): Unit = {
+    val proof     = ProofParserCNFTPTP.read("/home/eze/Escritorio/TPTP-Parsers/tests/splitTest.tptp")
+    val variables = ProofParserCNFTPTP.getSeenVars
+    println(variables)
+    println(proof)
+    val split     = new TestSplt(variables,Atom("p",Nil))
+    split(proof)
+    println(proof)
+  }
+}
+/**
+  * The class FOSplit
+  */
+abstract class FOSplit(val variables : MSet[Var]) extends (Proof[Node] => Proof[Node]) {
+
+  def equalLiterals(selectedLiteral : E , nodeLiteral : E) : Boolean
+
+  def selectLiteral(proof: Proof[Node]): E
+
+  def split(proof: Proof[Node], selectedLiteral : E): (Node,Node) = {
+    def manageContraction(node : Node, fixedPremises : Seq[(Node,Node)]) : (Node , Node) = {
+      require(fixedPremises.length == 1)
+      val (left,right) = fixedPremises.head
+      (Contraction(left)(variables),Contraction(right)(variables))
+    }
+
+    def manageResolution(node : Node ,fixedPremises : Seq[(Node,Node)]) : (Node,Node) = {
+      def contains(sequent : SeqSequent,literal : E) : Boolean = {
+        sequent.ant.filter(equalLiterals(literal,_)).nonEmpty || sequent.suc.filter(equalLiterals(literal,_)).nonEmpty
+      }
+      require(fixedPremises.length == 2)
+      lazy val (fixedLeftPos, fixedLeftNeg)   = fixedPremises.head
+      lazy val (fixedRightPos, fixedRightNeg) = fixedPremises.last
+      val (leftPremise,rightPremise,leftResolvedLiteral,rightResolvedLiteral) =
+        node match {
+          case UnifyingResolution(lp, rp, lrl, rrl) => (lp, rp, lrl, rrl)
+        }
+      if(equalLiterals(selectedLiteral,leftResolvedLiteral)) (fixedLeftPos, fixedRightNeg)
+      else {
+        val (leftConclusionPos, leftConclusionNeg) = (fixedLeftPos.conclusion, fixedLeftNeg.conclusion)
+        val (rightConclusionPos, rightConclusionNeg) = (fixedRightPos.conclusion, fixedRightNeg.conclusion)
+        val finalLeftProof =
+          if(!contains(leftConclusionPos,leftResolvedLiteral)) fixedRightPos
+          else if(!contains(rightConclusionPos,rightResolvedLiteral)) fixedLeftPos
+          else UnifyingResolution.resolve(fixedLeftPos,fixedRightPos,variables)
+        val finalRighttProof =
+          if(!contains(leftConclusionNeg,leftResolvedLiteral)) fixedRightNeg
+          else if(!contains(rightConclusionNeg,rightResolvedLiteral)) fixedLeftNeg
+          else UnifyingResolution.resolve(fixedLeftNeg,fixedRightNeg,variables)
+        (finalLeftProof,finalRighttProof)
+      }
+
+    }
+
+    proof foldDown { (node: Node, fixedPremises: Seq[(Node, Node)]) =>
+      node match {
+        case Axiom(_)                    => (node, node)
+        case Contraction(_,_)            => manageContraction(node, fixedPremises)
+        case UnifyingResolution(_,_,_,_) => manageResolution(node, fixedPremises)
+      }
+    }
+
+  }
+
+
+  def applyOnce(p: Proof[Node]): Proof[Node] = {
+    val selectedLiteral = selectLiteral(p)
+    val (left, right)   = split(p, selectedLiteral)
+    val leftContracted  = Contraction(left)(variables)
+    val rightContracted = Contraction(right)(variables)
+    val compressedProof : Proof[Node] = UnifyingResolution.resolve(leftContracted,rightContracted,variables)
+    println(compressedProof)
+    compressedProof//if (compressedProof.size < p.size) compressedProof else p
+  }
+}
+
+abstract class SimpleSplit(override val variables : MSet[Var], val literal : E) extends FOSplit(variables) {
+  def selectLiteral(proof: Proof[Node]) : E = literal
+  def apply(p: Proof[Node]):Proof[Node] = applyOnce(p)
+}
+
+class TestSplt(override val variables : MSet[Var], override val literal : E)
+extends SimpleSplit(variables,literal) with NameEquality

--- a/src/main/scala/at/logic/skeptik/algorithm/compressor/FOSplit/FOSplit.scala
+++ b/src/main/scala/at/logic/skeptik/algorithm/compressor/FOSplit/FOSplit.scala
@@ -61,10 +61,10 @@ abstract class FOSplit(val variables : MSet[Var]) extends (Proof[Node] => Proof[
       def containsPos(sequent: SeqSequent, literal: E) : Boolean = seqContains(sequent.suc,literal)
       def containsNeg(sequent: SeqSequent, literal: E) : Boolean = seqContains(sequent.ant,literal)
       def contains(sequent: SeqSequent, literal: E) : Boolean = containsPos(sequent,literal) || containsNeg(sequent,literal)
-      def contractAndUnify(leftNode : Node ,rightNode:Node) =
-        UnifyingResolution.resolve(Contraction.contractIfPossible(leftNode,variables),
+      def contractAndUnify(leftNode : Node ,rightNode:Node) = UnifyingResolution.resolve(leftNode,rightNode,variables)
+      /*  UnifyingResolution.resolve(Contraction.contractIfPossible(leftNode,variables),
                                    Contraction.contractIfPossible(rightNode,variables),
-                                   variables)
+                                   variables)*/
 
       require(fixedPremises.length == 2)
       lazy val (fixedLeftPos, fixedLeftNeg) = fixedPremises.head
@@ -119,6 +119,13 @@ abstract class FOSplit(val variables : MSet[Var]) extends (Proof[Node] => Proof[
 
 
   def applyOnce(p: Proof[Node]): Proof[Node] = {
+    def countResolutionNodes(p: Proof[Node]): Int = {
+      var count = 0
+      for (n <- p.nodes)
+        if (n.isInstanceOf[UnifyingResolution])
+          count = count + 1
+      count
+    }
     if(selectLiteral(p).isEmpty)
       p
     else {
@@ -127,7 +134,7 @@ abstract class FOSplit(val variables : MSet[Var]) extends (Proof[Node] => Proof[
       val leftContracted = Contraction.contractIfPossible(left, variables)
       val rightContracted = Contraction.contractIfPossible(right, variables)
       val compressedProof: Proof[Node] = UnifyingResolution.resolve(leftContracted, rightContracted, variables)
-      if (compressedProof.size < p.size) compressedProof else p
+      if (countResolutionNodes(compressedProof) < countResolutionNodes(p)) compressedProof else p
     }
   }
 }

--- a/src/main/scala/at/logic/skeptik/algorithm/compressor/FOSplit/FOSplit.scala
+++ b/src/main/scala/at/logic/skeptik/algorithm/compressor/FOSplit/FOSplit.scala
@@ -126,13 +126,14 @@ abstract class FOSplit(val variables : MSet[Var]) extends (Proof[Node] => Proof[
           count = count + 1
       count
     }
-    if(selectLiteral(p).isEmpty)
+    if(selectLiteral(p).isEmpty) {
+      //print("a");
       p
-    else {
+    } else {
       val selectedLiteral = selectLiteral(p).get
       val (left, right) = split(p, selectedLiteral)
-      println(left)
-      println(right)
+      //println(left)
+      //println(right)
       val leftContracted = Contraction.contractIfPossible(left, variables)
       val rightContracted = Contraction.contractIfPossible(right, variables)
       val compressedProof: Proof[Node] = UnifyingResolution.resolve(leftContracted, rightContracted, variables)

--- a/src/main/scala/at/logic/skeptik/algorithm/compressor/FOSplit/FOSplit.scala
+++ b/src/main/scala/at/logic/skeptik/algorithm/compressor/FOSplit/FOSplit.scala
@@ -131,6 +131,8 @@ abstract class FOSplit(val variables : MSet[Var]) extends (Proof[Node] => Proof[
     else {
       val selectedLiteral = selectLiteral(p).get
       val (left, right) = split(p, selectedLiteral)
+      println(left)
+      println(right)
       val leftContracted = Contraction.contractIfPossible(left, variables)
       val rightContracted = Contraction.contractIfPossible(right, variables)
       val compressedProof: Proof[Node] = UnifyingResolution.resolve(leftContracted, rightContracted, variables)

--- a/src/main/scala/at/logic/skeptik/algorithm/compressor/FOSplit/FOSplit.scala
+++ b/src/main/scala/at/logic/skeptik/algorithm/compressor/FOSplit/FOSplit.scala
@@ -62,18 +62,18 @@ abstract class FOSplit(val variables : MSet[Var]) extends (Proof[Node] => Proof[
       require(fixedPremises.length == 2)
       lazy val (fixedLeftPos, fixedLeftNeg) = fixedPremises.head
       lazy val (fixedRightPos, fixedRightNeg) = fixedPremises.last
-      val (leftPremise, rightPremise, leftResolvedLiteral, rightResolvedLiteral) =
+      val (leftResolvedLiteral, rightResolvedLiteral) =
         node match {
-          case UnifyingResolution(lp, rp, lrl, rrl) => (lp, rp, lrl, rrl)
+          case UnifyingResolution(_, _, lrl, rrl) => (lrl, rrl)
         }
       if (equalLiterals(selectedLiteral, leftResolvedLiteral)) {
         val premiseWithPositiveOcurrence =
-          if(fixedLeftPos.conclusion.suc.exists(equalLiterals(leftResolvedLiteral,_)))
+          if(containsPos(fixedLeftPos.conclusion,leftResolvedLiteral))
             fixedLeftPos
           else
             fixedRightPos
         val premiseWithNegativeOcurrence =
-          if(fixedRightNeg.conclusion.ant.exists(equalLiterals(leftResolvedLiteral,_)))
+          if(containsNeg(fixedRightNeg.conclusion,leftResolvedLiteral))
             fixedRightNeg
           else
             fixedLeftNeg

--- a/src/main/scala/at/logic/skeptik/algorithm/compressor/FOSplit/FOSplit.scala
+++ b/src/main/scala/at/logic/skeptik/algorithm/compressor/FOSplit/FOSplit.scala
@@ -29,8 +29,9 @@ object FOSplitTest {
     println(split(proof))
   }
 }
+
 /**
-  * The class FOSplit
+  * The class FOSplit is the base of the split procedure in First-Order logic
   */
 abstract class FOSplit(val variables : MSet[Var]) extends (Proof[Node] => Proof[Node]) {
 
@@ -47,6 +48,8 @@ abstract class FOSplit(val variables : MSet[Var]) extends (Proof[Node] => Proof[
 
     def manageResolution(node : Node ,fixedPremises : Seq[(Node,Node)]) : (Node,Node) = {
       def contains(sequent : SeqSequent,literal : E) : Boolean = {
+        // TODO: This will fail with a different implementation of equalLiterals. Replace it by a fixed implementation
+        //       that only compares the names (as the NameEquality trait currently does)
         sequent.ant.filter(equalLiterals(literal,_)).nonEmpty || sequent.suc.filter(equalLiterals(literal,_)).nonEmpty
       }
       require(fixedPremises.length == 2)

--- a/src/main/scala/at/logic/skeptik/algorithm/compressor/FOSplit/FOSplit.scala
+++ b/src/main/scala/at/logic/skeptik/algorithm/compressor/FOSplit/FOSplit.scala
@@ -1,6 +1,5 @@
 package at.logic.skeptik.algorithm.compressor.FOSplit
 
-import at.logic.skeptik.algorithm.compressor.FOSplit.equalities.NameEquality
 import at.logic.skeptik.expression.formula.Atom
 import at.logic.skeptik.expression.{E, Var}
 import at.logic.skeptik.judgment.immutable.SeqSequent
@@ -48,9 +47,13 @@ abstract class FOSplit(val variables : MSet[Var]) extends (Proof[Node] => Proof[
 
     def manageResolution(node : Node ,fixedPremises : Seq[(Node,Node)]) : (Node,Node) = {
       def contains(sequent : SeqSequent,literal : E) : Boolean = {
-        // TODO: This will fail with a different implementation of equalLiterals. Replace it by a fixed implementation
-        //       that only compares the names (as the NameEquality trait currently does)
-        sequent.ant.filter(equalLiterals(literal,_)).nonEmpty || sequent.suc.filter(equalLiterals(literal,_)).nonEmpty
+        def equalNames(selectedLiteral : E , nodeLiteral : E) : Boolean =
+          (selectedLiteral, nodeLiteral) match {
+            case (Atom(Var(name1,_), _), Atom(Var(name2,_), _)) => name1 == name2
+            case (Atom(Var(name1,_), _),          _           ) => false
+            case _                                              => throw new Exception("The literal is not an instance of an Atom\nLiterals: " + selectedLiteral.toString + ", " + nodeLiteral.toString)
+          }
+        sequent.ant.filter(equalNames(literal,_)).nonEmpty || sequent.suc.filter(equalLiterals(literal,_)).nonEmpty
       }
       require(fixedPremises.length == 2)
       lazy val (fixedLeftPos, fixedLeftNeg)   = fixedPremises.head

--- a/src/main/scala/at/logic/skeptik/algorithm/compressor/FOSplit/FOSplitHeuristic.scala
+++ b/src/main/scala/at/logic/skeptik/algorithm/compressor/FOSplit/FOSplitHeuristic.scala
@@ -2,7 +2,9 @@ package at.logic.skeptik.algorithm.compressor.FOSplit
 
 import at.logic.skeptik.algorithm.unifier.MartelliMontanari
 import at.logic.skeptik.expression.formula.Atom
+import at.logic.skeptik.expression.substitution.immutable.Substitution
 import at.logic.skeptik.expression.{App, E, Var}
+import at.logic.skeptik.judgment.immutable.{SeqSequent => Sequent}
 import at.logic.skeptik.proof.Proof
 import at.logic.skeptik.proof.sequent.lk.Axiom
 import at.logic.skeptik.proof.sequent.resolution.{Contraction, UnifyingResolution}
@@ -14,6 +16,15 @@ import scala.collection.mutable.{HashMap => MMap, HashSet => MSet}
   * Created by eze on 2016.06.13..
   */
 trait AbstractFOSplitHeuristic extends FOSplit {
+
+  protected def getLiteralName(literal: E) : String =
+    literal match {
+      case Atom(Var(name,_),_) => name
+      case App(function,arg)   => getLiteralName(function)
+      case Var(name,_)         => name
+      case _                   => throw new Exception("Literal name not found: " + literal.toString)
+    }
+
   def computeMeasures(proof: Proof[Node]): (MMap[String,Long],Long)
 
   def chooseVariable(literalAdditivity: collection.Map[String,Long], totalAdditivity: Long): Option[E]
@@ -26,14 +37,6 @@ trait AbstractFOSplitHeuristic extends FOSplit {
 
 
 trait SeenLiteralsHeuristic extends AbstractFOSplitHeuristic {
-
-  private def getLiteralName(literal: E) : String =
-    literal match {
-        case Atom(Var(name,_),_) => name
-        case App(function,arg)   => getLiteralName(function)
-        case Var(name,_)         => name
-        case _                   => throw new Exception("Literal name not found: " + literal.toString)
-    }
 
   private def unifyIfPossible(literal1 : Option[E] , literal2 : Option[E]) : Option[E] =
     if(literal1.isEmpty || literal2.isEmpty)
@@ -102,14 +105,6 @@ trait SeenLiteralsHeuristic extends AbstractFOSplitHeuristic {
 
 trait FOAdditivityHeuristic extends AbstractFOSplitHeuristic  {
 
-  private def getLiteralName(literal: E) : String =
-    literal match {
-      case Atom(Var(name,_),_) => name
-      case App(function,arg)   => getLiteralName(function)
-      case Var(name,_)         => name
-      case _                   => throw new Exception("Literal name not found: " + literal.toString)
-    }
-
   def computeMeasures(proof: Proof[Node]) = {
     var totalAdditivity = 0.toLong
     val literalAdditivity = MMap[String,Long]()
@@ -123,5 +118,248 @@ trait FOAdditivityHeuristic extends AbstractFOSplitHeuristic  {
     }
     proof.foreach(visit)
     (literalAdditivity, totalAdditivity)
+  }
+}
+
+
+/**
+  * In this heuristic we experiment with a restriction similar to the
+  * one implied in FORPI related to safe literals. Here we consider all
+  * the literals resolved.
+  */
+trait SetContentionHeuristic extends AbstractFOSplitHeuristic {
+
+  private def isIncludeInSet(sequent: Sequent,literalsSet : MSet[E]): Boolean = {
+    def desiredIsContained(computed: Sequent, desired: Sequent, unifiableVariables: MSet[Var]): Boolean = {
+      def findFromMap(m: MMap[Var, Set[E]], vars: MSet[Var]): Boolean = {
+        val subList = MSet[(Var, E)]()
+
+        for (k <- m.keySet)
+          if (m.get(k).get.nonEmpty)
+            subList.add((k, m.get(k).get.head))
+
+        val sub = Substitution(subList.toSeq: _*)
+        def foundExactly(target: Seq[E], source: Seq[E]): Boolean = {
+          if (target.isEmpty)
+            return true
+
+          target match {
+            case h :: t =>
+              for (s <- source)
+                if (h.equals(s))
+                  return foundExactly(t, source)
+          }
+          false
+        }
+
+        val newDesiredAnt = desired.ant.map(e => sub(e))
+
+        val newDesiredSuc = desired.suc.map(e => sub(e))
+        foundExactly(newDesiredAnt, computed.ant) && foundExactly(newDesiredSuc, computed.suc)
+      }
+
+      lazy val commonVars     = UnifyingResolution.getSetOfVars(Axiom(computed.ant)) intersect UnifyingResolution.getSetOfVars(Axiom(computed.suc))
+      lazy val antMap         = UnifyingResolution.generateSubstitutionOptions(computed.ant, desired.ant, unifiableVariables)
+      lazy val sucMap         = UnifyingResolution.generateSubstitutionOptions(computed.suc, desired.suc, unifiableVariables)
+      lazy val intersectedMap = UnifyingResolution.intersectMaps(antMap, sucMap)
+
+
+      (computed == desired) ||
+      (
+           !(UnifyingResolution.getSetOfVars(desired.ant: _*).nonEmpty && antMap.isEmpty)
+        && !(UnifyingResolution.getSetOfVars(desired.suc: _*).nonEmpty && sucMap.isEmpty)
+        && UnifyingResolution.validMap(intersectedMap, vars)
+        && findFromMap(intersectedMap, vars)
+      )
+    }
+
+    def sequentAntVars   = UnifyingResolution.getSetOfVars(sequent.ant: _*)
+    def sequentSucVars   = UnifyingResolution.getSetOfVars(sequent.suc: _*)
+    def litteralsSetVars = UnifyingResolution.getSetOfVars(literalsSet.toList : _*)
+    def vars : MSet[Var] = MSet[Var]() ++ sequentAntVars ++ sequentSucVars
+    def allvars          = vars ++ litteralsSetVars
+
+    def safeClean = UnifyingResolution.fixSharedNoFilter(Axiom(litteralsSetVars), Axiom(sequent), 0, allvars)
+
+    desiredIsContained(safeClean.conclusion, sequent,vars)
+  }
+
+  def exploreLiterals(proof: Proof[Node]) : MMap[String,Option[E]] = {
+    val nodesSets = MMap[Node, MSet[E]]()
+    val literals  = MMap[String, Option[E]]()
+
+    nodesSets +=  proof.root -> MSet[E](proof.root.conclusion.ant ++ proof.root.conclusion.suc :_* )
+
+    proof bottomUp { (node: Node, _ : Seq[Unit]) =>
+      node match {
+        case Axiom(_) => ()
+        case Contraction(premise, _) => nodesSets += premise -> nodesSets(node); ()
+        case UnifyingResolution(leftPremise, rightPremise, leftResolvedLiteral, rightResolvedLiteral) => {
+          val literalName = getLiteralName(leftResolvedLiteral)
+          val mgu         = MartelliMontanari((leftResolvedLiteral, rightResolvedLiteral) :: Nil)(this.variables) match {
+            case Some(s) => s
+            case None    => throw new Exception("Resolved Literasl can't be unified: " + leftResolvedLiteral.toString + ", " + rightResolvedLiteral.toString)
+          }
+          val unifiedLiteral : E = mgu(leftResolvedLiteral)
+          literals += literalName -> Some(unifiedLiteral)
+          nodesSets += leftPremise  -> (nodesSets(node) += unifiedLiteral)
+          nodesSets += rightPremise -> nodesSets(leftPremise)
+          if(!isIncludeInSet(leftPremise.conclusion,nodesSets(leftPremise)))
+            literals += literalName -> None
+          if(!isIncludeInSet(rightPremise.conclusion,nodesSets(rightPremise)))
+            literals += literalName -> None
+          ()
+        }
+      }
+    }
+    literals
+  }
+
+  def availableLiterals(literals : MMap[String,Option[E]]) : MSet[String] = {
+    val available = literals.filter(_._2.nonEmpty)
+    MSet(available.keys.toList: _*)
+  }
+
+  def computeMeasures(proof: Proof[Node]): (MMap[String,Long],Long)
+
+  def chooseVariable(literalAdditivity: collection.Map[String,Long], totalAdditivity: Long): Option[E]
+
+  override def selectLiteral(proof: Proof[Node]) = {
+    val (measureMap, measureSum) = computeMeasures(proof)
+    val literals : MSet[String] = availableLiterals(exploreLiterals(proof))
+    val availableLiteralsMap = measureMap.filter(x => literals.contains(x._1))
+    chooseVariable(availableLiteralsMap, measureSum)
+  }
+}
+
+
+//#####################################################
+//#####################################################
+//#####################################################
+
+/**
+  * EXPERIMENT
+  */
+trait SetContentionAndSeenLiteralsHeuristic extends AbstractFOSplitHeuristic {
+
+  private def unifyIfPossible(literal1 : Option[E] , literal2 : Option[E]) : Option[E] =
+    if(literal1.isEmpty || literal2.isEmpty)
+      None
+    else {
+      val mgu = MartelliMontanari((literal1.get,literal2.get)::Nil)(this.variables)
+      mgu match {
+        case None       => None
+        case Some(subs) => Some(subs(literal1.get))
+      }
+    }
+
+
+  private def isIncludeInSet(sequent: Sequent,literalsSet : MSet[E]): Boolean = {
+    def desiredIsContained(computed: Sequent, desired: Sequent, unifiableVariables: MSet[Var]): Boolean = {
+      def findFromMap(m: MMap[Var, Set[E]], vars: MSet[Var]): Boolean = {
+        val subList = MSet[(Var, E)]()
+
+        for (k <- m.keySet)
+          if (m.get(k).get.nonEmpty)
+            subList.add((k, m.get(k).get.head))
+
+        val sub = Substitution(subList.toSeq: _*)
+        def foundExactly(target: Seq[E], source: Seq[E]): Boolean = {
+          if (target.isEmpty)
+            return true
+
+          target match {
+            case h :: t =>
+              for (s <- source)
+                if (h.equals(s))
+                  return foundExactly(t, source)
+          }
+          false
+        }
+
+        val newDesiredAnt = desired.ant.map(e => sub(e))
+
+        val newDesiredSuc = desired.suc.map(e => sub(e))
+        foundExactly(newDesiredAnt, computed.ant) && foundExactly(newDesiredSuc, computed.suc)
+      }
+
+      lazy val commonVars     = UnifyingResolution.getSetOfVars(Axiom(computed.ant)) intersect UnifyingResolution.getSetOfVars(Axiom(computed.suc))
+      lazy val antMap         = UnifyingResolution.generateSubstitutionOptions(computed.ant, desired.ant, unifiableVariables)
+      lazy val sucMap         = UnifyingResolution.generateSubstitutionOptions(computed.suc, desired.suc, unifiableVariables)
+      lazy val intersectedMap = UnifyingResolution.intersectMaps(antMap, sucMap)
+
+
+      (computed == desired) ||
+        (
+          !(UnifyingResolution.getSetOfVars(desired.ant: _*).nonEmpty && antMap.isEmpty)
+            && !(UnifyingResolution.getSetOfVars(desired.suc: _*).nonEmpty && sucMap.isEmpty)
+            && UnifyingResolution.validMap(intersectedMap, vars)
+            && findFromMap(intersectedMap, vars)
+          )
+    }
+
+    def sequentAntVars   = variables//UnifyingResolution.getSetOfVars(sequent.ant: _*)
+    def sequentSucVars   = variables//UnifyingResolution.getSetOfVars(sequent.suc: _*)
+    def litteralsSetVars = variables//UnifyingResolution.getSetOfVars(literalsSet.toList : _*)
+    def vars : MSet[Var] = MSet(variables.toList:_*)//MSet[Var]() ++ sequentAntVars ++ sequentSucVars
+    def allvars          = vars ++ litteralsSetVars
+
+    def safeClean = UnifyingResolution.fixSharedNoFilter(Axiom(litteralsSetVars), Axiom(sequent), 0, allvars)
+
+    desiredIsContained(safeClean.conclusion, sequent,vars)
+  }
+
+  def exploreLiterals(proof: Proof[Node]) : MMap[String,Option[E]] = {
+    val nodesSets = MMap[Node, MSet[E]]()
+    val literals  = MMap[String, Option[E]]()
+
+    nodesSets +=  proof.root -> MSet[E](proof.root.conclusion.ant ++ proof.root.conclusion.suc :_* )
+
+    proof bottomUp { (node: Node, _ : Seq[Unit]) =>
+      node match {
+        case Axiom(_) => ()
+        case Contraction(premise, _) => nodesSets += premise -> nodesSets(node) ; ()
+        case UnifyingResolution(leftPremise, rightPremise, leftResolvedLiteral, rightResolvedLiteral) => {
+          val literalName = getLiteralName(leftResolvedLiteral)
+          val mgu         = MartelliMontanari((leftResolvedLiteral, rightResolvedLiteral) :: Nil)(this.variables) match {
+            case Some(s) => s
+            case None    => throw new Exception("Resolved Literasl can't be unified: " + leftResolvedLiteral.toString + ", " + rightResolvedLiteral.toString)
+          }
+          val unifiedLiteral : E = mgu(leftResolvedLiteral)
+          if(literals.contains(literalName)) {
+            val oldLiteral = literals.get(literalName).get
+            val newLiteral = unifyIfPossible(oldLiteral,Some(unifiedLiteral))
+            literals += (literalName -> newLiteral)
+          }
+          else
+            literals += (literalName -> Some(unifiedLiteral))
+
+          nodesSets += leftPremise  -> (nodesSets(node) += unifiedLiteral)
+          nodesSets += rightPremise -> nodesSets(leftPremise)
+          if(!isIncludeInSet(leftPremise.conclusion,nodesSets(leftPremise)))
+            literals += literalName -> None
+          if(!isIncludeInSet(rightPremise.conclusion,nodesSets(rightPremise)))
+            literals += literalName -> None
+          ()
+        }
+      }
+    }
+    literals
+  }
+
+  def availableLiterals(literals : MMap[String,Option[E]]) : MSet[String] = {
+    val available = literals.filter(_._2.nonEmpty)
+    MSet(available.keys.toList: _*)
+  }
+
+  def computeMeasures(proof: Proof[Node]): (MMap[String,Long],Long)
+
+  def chooseVariable(literalAdditivity: collection.Map[String,Long], totalAdditivity: Long): Option[E]
+
+  override def selectLiteral(proof: Proof[Node]) = {
+    val (measureMap, measureSum) = computeMeasures(proof)
+    val literals : MSet[String] = availableLiterals(exploreLiterals(proof))
+    val availableLiteralsMap = measureMap.filter(x => literals.contains(x._1))
+    chooseVariable(availableLiteralsMap, measureSum)
   }
 }

--- a/src/main/scala/at/logic/skeptik/algorithm/compressor/FOSplit/FOSplitHeuristic.scala
+++ b/src/main/scala/at/logic/skeptik/algorithm/compressor/FOSplit/FOSplitHeuristic.scala
@@ -1,0 +1,78 @@
+package at.logic.skeptik.algorithm.compressor.FOSplit
+
+import at.logic.skeptik.algorithm.unifier.MartelliMontanari
+import at.logic.skeptik.expression.formula.Atom
+import at.logic.skeptik.expression.{E, Var}
+import at.logic.skeptik.proof.Proof
+import at.logic.skeptik.proof.sequent.lk.Axiom
+import at.logic.skeptik.proof.sequent.resolution.{Contraction, UnifyingResolution}
+import at.logic.skeptik.proof.sequent.{SequentProofNode => Node}
+
+import scala.collection.mutable.{HashMap => MMap, HashSet => MSet}
+
+/**
+  * Created by eze on 2016.06.13..
+  */
+trait AbstractFOSplitHeuristic extends FOSplit {
+  def computeMeasures(proof: Proof[Node]): (MMap[E,Long],Long)
+
+  def chooseVariable(literalAdditivity: collection.Map[E,Long], totalAdditivity: Long): E
+
+  def selectLiteral(proof: Proof[Node]) = {
+    val (measureMap, measureSum) = computeMeasures(proof)
+    chooseVariable(measureMap, measureSum)
+  }
+}
+
+trait SeenLiteralsHeuristic extends AbstractFOSplitHeuristic {
+  def exploreLiterals(proof: Proof[Node]) : MMap[String,Option[E]] = {
+    def getLiteralName(literal: E) : String = literal match {
+      case Atom(Var(name,_),_) => name
+      case _                   => throw new Exception("Literal name not found: " + literal.toString)
+    }
+    def unifyIfPossible(literal1 : Option[E] , literal2 : Option[E]) : Option[E] = {
+      if(literal1.isEmpty || literal2.isEmpty)
+        None
+      else {
+        val mgu = MartelliMontanari((literal1.get,literal2.get)::Nil)(this.variables)
+        mgu match {
+          case None       => None
+          case Some(subs) => Some(subs(literal1.get))
+        }
+      }
+    }
+    val literals = MMap[String, Option[E]]()
+    proof foldDown { (node: Node, _: Seq[Unit]) =>
+      node match {
+        case Axiom(_)          => ()
+        case Contraction(_, _) => ()
+        case UnifyingResolution(_, _, leftResolvedLiteral, rightResolvedLiteral) => {
+          val literalName = getLiteralName(leftResolvedLiteral)
+          val mgu         = MartelliMontanari((leftResolvedLiteral, rightResolvedLiteral) :: Nil)(this.variables) match {
+            case Some(s) => s
+            case None    => throw new Exception("Resolved Literasl can't be unified: " + leftResolvedLiteral.toString + ", " + rightResolvedLiteral.toString)
+          }
+          val unifiedLiteral = mgu(leftResolvedLiteral)
+          if(literals.contains(literalName)) {
+            val oldLiteral = literals.get(literalName).get
+            val newLiteral = unifyIfPossible(oldLiteral,Some(unifiedLiteral))
+            literals += (literalName -> newLiteral)
+          }
+          else
+            literals += (literalName -> Some(unifiedLiteral))
+          ()
+        }
+      }
+    }
+    literals
+  }
+
+  def availableLiterals(literals : MMap[String,Option[(E,E)]]) : MSet[String] = {
+    val available = literals.filter(_._2.nonEmpty)
+    MSet(available.keys.toList: _*)
+  }
+
+  def computeMeasures(proof: Proof[Node]): (MMap[E,Long],Long)
+
+  def chooseVariable(literalAdditivity: collection.Map[E,Long], totalAdditivity: Long): E
+}

--- a/src/main/scala/at/logic/skeptik/algorithm/compressor/FOSplit/FOSplitHeuristic.scala
+++ b/src/main/scala/at/logic/skeptik/algorithm/compressor/FOSplit/FOSplitHeuristic.scala
@@ -2,7 +2,7 @@ package at.logic.skeptik.algorithm.compressor.FOSplit
 
 import at.logic.skeptik.algorithm.unifier.MartelliMontanari
 import at.logic.skeptik.expression.formula.Atom
-import at.logic.skeptik.expression.{E, Var}
+import at.logic.skeptik.expression.{App, E, Var}
 import at.logic.skeptik.proof.Proof
 import at.logic.skeptik.proof.sequent.lk.Axiom
 import at.logic.skeptik.proof.sequent.resolution.{Contraction, UnifyingResolution}
@@ -16,7 +16,7 @@ import scala.collection.mutable.{HashMap => MMap, HashSet => MSet}
 trait AbstractFOSplitHeuristic extends FOSplit {
   def computeMeasures(proof: Proof[Node]): (MMap[String,Long],Long)
 
-  def chooseVariable(literalAdditivity: collection.Map[String,Long], totalAdditivity: Long): E
+  def chooseVariable(literalAdditivity: collection.Map[String,Long], totalAdditivity: Long): Option[E]
 
   def selectLiteral(proof: Proof[Node]) = {
     val (measureMap, measureSum) = computeMeasures(proof)
@@ -30,6 +30,8 @@ trait SeenLiteralsHeuristic extends AbstractFOSplitHeuristic {
   private def getLiteralName(literal: E) : String =
     literal match {
         case Atom(Var(name,_),_) => name
+        case App(function,arg)   => getLiteralName(function)
+        case Var(name,_)         => name
         case _                   => throw new Exception("Literal name not found: " + literal.toString)
     }
 
@@ -88,7 +90,7 @@ trait SeenLiteralsHeuristic extends AbstractFOSplitHeuristic {
 
   def computeMeasures(proof: Proof[Node]): (MMap[String,Long],Long)
 
-  def chooseVariable(literalAdditivity: collection.Map[String,Long], totalAdditivity: Long): E
+  def chooseVariable(literalAdditivity: collection.Map[String,Long], totalAdditivity: Long): Option[E]
 
   override def selectLiteral(proof: Proof[Node]) = {
     val (measureMap, measureSum) = computeMeasures(proof)
@@ -103,6 +105,8 @@ trait FOAdditivityHeuristic extends AbstractFOSplitHeuristic  {
   private def getLiteralName(literal: E) : String =
     literal match {
       case Atom(Var(name,_),_) => name
+      case App(function,arg)   => getLiteralName(function)
+      case Var(name,_)         => name
       case _                   => throw new Exception("Literal name not found: " + literal.toString)
     }
 

--- a/src/main/scala/at/logic/skeptik/algorithm/compressor/FOSplit/FOSplitHeuristic.scala
+++ b/src/main/scala/at/logic/skeptik/algorithm/compressor/FOSplit/FOSplitHeuristic.scala
@@ -204,7 +204,10 @@ trait SetContentionHeuristic extends AbstractFOSplitHeuristic {
 
     def safeClean = fixSharedNoFilter(Axiom(literalsSet/*safeLit*/), Axiom(sequent), 0, allvars)
 
-    desiredIsContained(safeClean.conclusion, sequent)(vars)
+    def antVarsC = getSetOfVars(safeClean.conclusion.ant: _*)
+    def sucVarsC = getSetOfVars(safeClean.conclusion.suc: _*)
+    def allvarsNew = MSet[Var]() ++ antVars ++ sucVars ++ antVarsB ++ sucVarsB ++ antVarsC ++ sucVarsC
+    desiredIsContained(safeClean.conclusion, sequent)(allvarsNew)
   }
 
   def exploreLiterals(proof: Proof[Node]) : MMap[String,Option[E]] = {
@@ -316,11 +319,14 @@ trait SetContentionAndSeenLiteralsHeuristic extends SetContentionHeuristic {
           if(!isIncludeInSet(leftSeq,nodesSets(leftPremise))) {
             literals += literalName -> None
             println("Left NOT included:\nPremise: " + leftPremise.conclusion.toString +"\nSet: " + nodesSets(leftPremise).mkString(","))
+            println("Transformed Sequent: " + leftSeq.toString)
           }
-          val rightSeq = Sequent()(rightPremise.conclusion.ant ++ leftPremise.conclusion.suc :_*)
+          val rightSeq = Sequent()(rightPremise.conclusion.ant ++ rightPremise.conclusion.suc :_*)
           if(!isIncludeInSet(rightSeq,nodesSets(rightPremise))) {
             literals += literalName -> None
             println("Right NOT included:\nPremise: " + rightPremise.conclusion.toString +"\nSet: " + nodesSets(rightPremise).mkString(","))
+            println("Transformed Sequent: " + rightSeq.toString)
+
           }
           ()
         }

--- a/src/main/scala/at/logic/skeptik/algorithm/compressor/FOSplit/LiteralsEquality.scala
+++ b/src/main/scala/at/logic/skeptik/algorithm/compressor/FOSplit/LiteralsEquality.scala
@@ -1,14 +1,22 @@
-package at.logic.skeptik.algorithm.compressor.FOSplit.equalities
+package at.logic.skeptik.algorithm.compressor.FOSplit
 
 import at.logic.skeptik.expression.formula.Atom
 import at.logic.skeptik.expression.{E, Var}
+
+/**
+  * This trait implements the equality relation
+  * between two literals in First-Order logic.
+  */
+trait AbstractEquality extends FOSplit {
+  def equalLiterals(selectedLiteral: E, nodeLiteral: E): Boolean
+}
 
 /**
   * This equality is used when we consider that two literals are equal if they have the same name
   * For example, the following literals would be considered equal: P(X), P(a), P(b). (X is a variable,
   * a and b are constante). P is the "name" of the three literals
   */
-trait NameEquality {
+trait NameEquality extends AbstractEquality {
   def equalLiterals(selectedLiteral: E, nodeLiteral: E): Boolean =
     (selectedLiteral, nodeLiteral) match {
       case (Atom(Var(name1,_), _), Atom(Var(name2,_), _)) => name1 == name2

--- a/src/main/scala/at/logic/skeptik/algorithm/compressor/FOSplit/LiteralsEquality.scala
+++ b/src/main/scala/at/logic/skeptik/algorithm/compressor/FOSplit/LiteralsEquality.scala
@@ -1,7 +1,7 @@
 package at.logic.skeptik.algorithm.compressor.FOSplit
 
 import at.logic.skeptik.expression.formula.Atom
-import at.logic.skeptik.expression.{E, Var}
+import at.logic.skeptik.expression.{App, E, Var}
 
 /**
   * This trait implements the equality relation
@@ -20,6 +20,9 @@ trait NameEquality extends AbstractEquality {
   def equalLiterals(selectedLiteral: E, nodeLiteral: E): Boolean =
     (selectedLiteral, nodeLiteral) match {
       case (Atom(Var(name1,_), _), Atom(Var(name2,_), _)) => name1 == name2
+      case (App(function,_), x)                           => equalLiterals(function,x)
+      case (x, App(function,_))                           => equalLiterals(x,function)
+      case (Var(name1,_),Var(name2,_))                    => name1 == name2
       case (Atom(Var(name1,_), _),          _           ) => false
       case _                                              => throw new Exception("The literal is not an instance of an Atom\nLiterals: " + selectedLiteral.toString + ", " + nodeLiteral.toString)
     }

--- a/src/main/scala/at/logic/skeptik/algorithm/compressor/FOSplit/equalities/NameEquality.scala
+++ b/src/main/scala/at/logic/skeptik/algorithm/compressor/FOSplit/equalities/NameEquality.scala
@@ -11,8 +11,8 @@ import at.logic.skeptik.expression.{E, Var}
 trait NameEquality {
   def equalLiterals(selectedLiteral: E, nodeLiteral: E): Boolean =
     (selectedLiteral, nodeLiteral) match {
-      case (Atom(name1, _), Atom(name2, _)) => name1 == name2
-      case (Atom(name1, _),      _       )  => false
-      case _                                => throw new Exception("The literal is not an instance of an Atom\nLiterals: " + selectedLiteral.toString + ", " + nodeLiteral.toString)
+      case (Atom(Var(name1,_), _), Atom(Var(name2,_), _)) => name1 == name2
+      case (Atom(Var(name1,_), _),          _           ) => false
+      case _                                              => throw new Exception("The literal is not an instance of an Atom\nLiterals: " + selectedLiteral.toString + ", " + nodeLiteral.toString)
     }
 }

--- a/src/main/scala/at/logic/skeptik/algorithm/compressor/FOSplit/equalities/NameEquality.scala
+++ b/src/main/scala/at/logic/skeptik/algorithm/compressor/FOSplit/equalities/NameEquality.scala
@@ -1,0 +1,18 @@
+package at.logic.skeptik.algorithm.compressor.FOSplit.equalities
+
+import at.logic.skeptik.expression.formula.Atom
+import at.logic.skeptik.expression.{E, Var}
+
+/**
+  * This equality is used when we consider that two literals are equal if they have the same name
+  * For example, the following literals would be considered equal: P(X), P(a), P(b). (X is a variable,
+  * a and b are constante). P is the "name" of the three literals
+  */
+trait NameEquality {
+  def equalLiterals(selectedLiteral: E, nodeLiteral: E): Boolean =
+    (selectedLiteral, nodeLiteral) match {
+      case (Atom(name1, _), Atom(name2, _)) => name1 == name2
+      case (Atom(name1, _),      _       )  => false
+      case _                                => throw new Exception("The literal is not an instance of an Atom\nLiterals: " + selectedLiteral.toString + ", " + nodeLiteral.toString)
+    }
+}

--- a/src/main/scala/at/logic/skeptik/parser/ProofParserSPASS.scala
+++ b/src/main/scala/at/logic/skeptik/parser/ProofParserSPASS.scala
@@ -26,6 +26,9 @@ trait SPASSParsers
 
   private val vars = Set[Var]()
 
+  def getVars() = vars.clone()
+  def cleanVars() = vars.clear()
+
   private val exprMap = new MMap[String, E] //will map axioms/proven expressions to the location (line number) where they were proven
 
   private val varMap = new MMap[String, E] //will map variable names to an expression object for that variable
@@ -87,7 +90,7 @@ trait SPASSParsers
         UnifyingResolution(firstPremise, secondPremise, desiredSequent)(vars)
       } catch {
         case e: Exception => {
-          e.printStackTrace()
+          //e.printStackTrace()
           UnifyingResolution(secondPremise, firstPremise, desiredSequent)(vars)
         }
       }
@@ -115,7 +118,7 @@ trait SPASSParsers
           UnifyingResolutionMRR(firstPremise, secondPremise, desiredSequent)(vars)
         } catch {
           case e: Exception => {
-            e.printStackTrace()
+            //e.printStackTrace()
             UnifyingResolutionMRR(secondPremise, firstPremise, desiredSequent)(vars)
           }
         }

--- a/src/main/scala/at/logic/skeptik/proof/Proof.scala
+++ b/src/main/scala/at/logic/skeptik/proof/Proof.scala
@@ -45,6 +45,17 @@ extends Iterable[P]
   override lazy val size:Int = nodes.length
 
 
+  /**
+    * The method foldDown consumes the proof in a topDown traversal (i.e. from the leaves
+    * to the root). It applyies the function taken as parameter to each node.
+    * In the case of the leaves of the proof, the second parameter of f will be Nil
+    *
+    * @param f  The function f takes the current node visited and a sequence of the results of the
+    *           recursive calls of f in the parents of the current node (a node is the child of its
+    *           premises)
+    * @tparam X The type of the result generated after consuming the proof
+    * @return   The recursive consumption of the proof applying the function f
+    */
   def foldDown[X](f: (P, Seq[X]) => X): X = {
     val resultFrom = MMap[P,X]()
     @tailrec def iterate(pos:Int):Unit = {
@@ -70,6 +81,16 @@ extends Iterable[P]
     resultFrom(nodes(permutation(0)))
   }
 
+  /**
+    * The method bottomUp traverse the proof in a bottomUp traversal (i.e. from the
+    * root to the leaves). It applyies the function taken as parameter to each node.
+    * In the case of the root of the proof, the second parameter of f will be Nil
+    *
+    * @param f  The function f takes the current node visited and a sequence of the results of the
+    *           recursive calls of f in the children of the current node (a node is the child of its
+    *           premises)
+    * @tparam X The type of the result generated after consuming the proof
+    */
   def bottomUp[X](f:(P, Seq[X])=>X):Unit = {
     val resultsFromChildren = MMap[P, Seq[X]]()
     @tailrec def iterate(pos:Int):Unit = {
@@ -83,7 +104,7 @@ extends Iterable[P]
     iterate(0)
   }
   
-    def bottomUp2[X](f:(P, Seq[X])=>X, permutation: Seq[Int]):Unit = {
+  def bottomUp2[X](f:(P, Seq[X])=>X, permutation: Seq[Int]):Unit = {
     val resultsFromChildren = MMap[P, Seq[X]]()
     @tailrec def iterate(pos:Int):Unit = {
       if (pos >= size) return
@@ -96,14 +117,24 @@ extends Iterable[P]
     iterate(0)
   }
 
+  /**
+    * The method topDown traverse the proof in a topDown traversal (i.e. from the
+    * leaves to the root). It applyies the function taken as parameter to each node.
+    * In the case of the leaves of the proof, the second parameter of f will be Nil
+    *
+    * @param f  The function f takes the current node visited and a sequence of the results of the
+    *           recursive calls of f in the parents of the current node (a node is the child of its
+    *           premises)
+    * @tparam X The type of the result generated after consuming the proof
+    */
   def topDown[X](f: (P, Seq[X]) => X): Unit = {
-    val resultsFromChildren = MMap[P, Seq[X]]()
+    val resultsFromParents = MMap[P, Seq[X]]()
     @tailrec def iterate(pos: Int): Unit = {
       if (pos < 0) return
       val node = nodes(pos)
-      val result = f(node, resultsFromChildren.getOrElse(node, Nil))
-      resultsFromChildren -= node
-      node.premises.foreach(premise => resultsFromChildren(premise) = (result +: resultsFromChildren.getOrElse(premise, Seq())))
+      val result = f(node, resultsFromParents.getOrElse(node, Nil))
+      resultsFromParents -= node
+      node.premises.foreach(premise => resultsFromParents(premise) = (result +: resultsFromParents.getOrElse(premise, Seq())))
       iterate(pos - 1)
     }
     iterate(nodes.length - 1)

--- a/src/main/scala/at/logic/skeptik/proof/sequent/resolution/Contraction.scala
+++ b/src/main/scala/at/logic/skeptik/proof/sequent/resolution/Contraction.scala
@@ -219,4 +219,10 @@ object Contraction {
     case p: Contraction => Some((p.premise, p.desired))
     case _ => None
   }
+
+  def contractIfPossible(premise: SequentProofNode, variables: MSet[Var]) : SequentProofNode = {
+    val contractedPremise = apply(premise)(variables)
+    if (contractedPremise.conclusion == premise.conclusion) premise
+    else contractedPremise
+  }
 }

--- a/src/main/scala/at/logic/skeptik/proof/sequent/resolution/UnifyingResolution.scala
+++ b/src/main/scala/at/logic/skeptik/proof/sequent/resolution/UnifyingResolution.scala
@@ -51,36 +51,45 @@ object UnifyingResolution extends CanRenameVariables with FindDesiredSequent {
 	def apply(leftPremise: SequentProofNode, rightPremise: SequentProofNode, desired: Sequent)(implicit unifiableVariables: MSet[Var]) = {
 		val leftPremiseClean = fixSharedNoFilter(leftPremise, rightPremise, 0, unifiableVariables)
 
-				val unifiablePairs = (for (auxL <- leftPremiseClean.conclusion.suc; auxR <- rightPremise.conclusion.ant) yield (auxL, auxR)).filter(isUnifiable)
-				if (unifiablePairs.length > 0) {
-					findDesiredSequent(unifiablePairs, desired, leftPremise, rightPremise, leftPremiseClean, false)
-				} else if (unifiablePairs.length == 0) {
-					throw new Exception("Resolution: the conclusions of the given premises are not resolvable. A")
-				} else {
-					//Should never really be reached in this constructor
-					throw new Exception("Resolution: the resolvent is ambiguous.")
-				}
+		val unifiablePairs = (for (auxL <- leftPremiseClean.conclusion.suc; auxR <- rightPremise.conclusion.ant) yield (auxL, auxR)).filter(isUnifiable)
+		if (unifiablePairs.length > 0) {
+			findDesiredSequent(unifiablePairs, desired, leftPremise, rightPremise, leftPremiseClean, false)
+		} else if (unifiablePairs.length == 0) {
+			throw new Exception("Resolution: the conclusions of the given premises are not resolvable. A")
+		} else {
+			//Should never really be reached in this constructor
+			throw new Exception("Resolution: the resolvent is ambiguous.")
+		}
 	}
 
 	def apply(leftPremise: SequentProofNode, rightPremise: SequentProofNode)(implicit unifiableVariables: MSet[Var]) = {
 
 		val leftPremiseClean = fixSharedNoFilter(leftPremise, rightPremise, 0, unifiableVariables)
-				val unifiablePairs = (for (auxL <- leftPremiseClean.conclusion.suc; auxR <- rightPremise.conclusion.ant) yield (auxL, auxR)).filter(isUnifiable)
+		val unifiablePairs = (for (auxL <- leftPremiseClean.conclusion.suc; auxR <- rightPremise.conclusion.ant) yield (auxL, auxR)).filter(isUnifiable)
 
-				if (unifiablePairs.length == 1) {
-					val (auxL, auxR) = unifiablePairs(0)
-							new UnifyingResolution(leftPremise, rightPremise, auxL, auxR, leftPremiseClean, null)
-				} else if (unifiablePairs.length == 0) {
-					throw new Exception("Resolution: the conclusions of the given premises are not resolvable. B")
-				} else {
-					throw new Exception("Resolution: the resolvent is ambiguous.")
-				}
+		if (unifiablePairs.length == 1) {
+			val (auxL, auxR) = unifiablePairs(0)
+			new UnifyingResolution(leftPremise, rightPremise, auxL, auxR, leftPremiseClean, null)
+		} else if (unifiablePairs.length == 0) {
+			throw new Exception("Resolution: the conclusions of the given premises are not resolvable. B")
+		} else {
+			throw new Exception("Resolution: the resolvent is ambiguous.")
+		}
 	}
+
 	def unapply(p: SequentProofNode) = p match {
-	case p: UnifyingResolution => Some((p.leftPremise, p.rightPremise, p.auxL, p.auxR))
-	case _ => None
+		case p: UnifyingResolution => Some((p.leftPremise, p.rightPremise, p.auxL, p.auxR))
+		case _ => None
 	}
 
+	def resolve(leftPremise: SequentProofNode, rightPremise: SequentProofNode, unifiableVariables: MSet[Var]): UnifyingResolution = {
+		try {
+		  apply(leftPremise, rightPremise)(unifiableVariables)
+	  } catch {
+			case e: Exception =>
+				apply(rightPremise, leftPremise)(unifiableVariables)
+		}
+	}
 }
 
 

--- a/src/main/scala/at/logic/skeptik/proof/sequent/resolution/UnifyingResolution.scala
+++ b/src/main/scala/at/logic/skeptik/proof/sequent/resolution/UnifyingResolution.scala
@@ -71,9 +71,9 @@ object UnifyingResolution extends CanRenameVariables with FindDesiredSequent {
 			val (auxL, auxR) = unifiablePairs(0)
 			new UnifyingResolution(leftPremise, rightPremise, auxL, auxR, leftPremiseClean, null)
 		} else if (unifiablePairs.length == 0) {
-			throw new Exception("Resolution: the conclusions of the given premises are not resolvable. B")
+			throw new Exception("Resolution: the conclusions of the given premises are not resolvable. B\nLeft premise: " + leftPremise.toString() +"\nRight premise: " + rightPremise.toString())
 		} else {
-			throw new Exception("Resolution: the resolvent is ambiguous.")
+			throw new Exception("Resolution: the resolvent is ambiguous.\nLeft premise: " + leftPremise.toString() +"\nRight premise: " + rightPremise.toString())
 		}
 	}
 

--- a/src/main/scala/at/logic/skeptik/proof/sequent/resolution/UnifyingResolution.scala
+++ b/src/main/scala/at/logic/skeptik/proof/sequent/resolution/UnifyingResolution.scala
@@ -55,10 +55,10 @@ object UnifyingResolution extends CanRenameVariables with FindDesiredSequent {
 		if (unifiablePairs.length > 0) {
 			findDesiredSequent(unifiablePairs, desired, leftPremise, rightPremise, leftPremiseClean, false)
 		} else if (unifiablePairs.length == 0) {
-			throw new Exception("Resolution: the conclusions of the given premises are not resolvable. A")
+			throw new Exception("Resolution: the conclusions of the given premises are not resolvable. A\nLeft premise: " + leftPremise.toString() +"\nRight premise: " + rightPremise.toString() + "\nVariables: " + unifiableVariables.mkString(","))
 		} else {
 			//Should never really be reached in this constructor
-			throw new Exception("Resolution: the resolvent is ambiguous.")
+			throw new Exception("Resolution: the resolvent is ambiguous.\nLeft premise: " + leftPremise.toString() +"\nRight premise: " + rightPremise.toString() + "\nVariables: " + unifiableVariables.mkString(","))
 		}
 	}
 
@@ -71,9 +71,9 @@ object UnifyingResolution extends CanRenameVariables with FindDesiredSequent {
 			val (auxL, auxR) = unifiablePairs(0)
 			new UnifyingResolution(leftPremise, rightPremise, auxL, auxR, leftPremiseClean, null)
 		} else if (unifiablePairs.length == 0) {
-			throw new Exception("Resolution: the conclusions of the given premises are not resolvable. B\nLeft premise: " + leftPremise.toString() +"\nRight premise: " + rightPremise.toString())
+			throw new Exception("Resolution: the conclusions of the given premises are not resolvable. B\nLeft premise: " + leftPremise.toString() +"\nRight premise: " + rightPremise.toString() + "\nVariables: " + unifiableVariables.mkString(","))
 		} else {
-			throw new Exception("Resolution: the resolvent is ambiguous.\nLeft premise: " + leftPremise.toString() +"\nRight premise: " + rightPremise.toString())
+			throw new Exception("Resolution: the resolvent is ambiguous.\nLeft premise: " + leftPremise.toString() +"\nRight premise: " + rightPremise.toString() + "\nVariables: " + unifiableVariables.mkString(","))
 		}
 	}
 

--- a/src/test/scala/at/logic/skeptik/algorithm/compressor/FOSplittingExperiment.scala
+++ b/src/test/scala/at/logic/skeptik/algorithm/compressor/FOSplittingExperiment.scala
@@ -1,0 +1,153 @@
+package at.logic.skeptik.algorithm.compressor
+
+import at.logic.skeptik.proof.Proof
+import at.logic.skeptik.proof.sequent.SequentProofNode
+import at.logic.skeptik.proof.sequent.resolution.{FOSubstitution, UnifyingResolution}
+import at.logic.skeptik.parser.ProofParserSPASS
+
+import collection.mutable.{HashSet => MSet}
+import java.io.PrintWriter
+
+import at.logic.skeptik.algorithm.compressor.FOSplit.FOCottonSplit
+
+import scala.io.Source
+
+
+/**
+  * This object is created to
+  */
+object FOSplittingExperiment {
+
+  def countNonResolutionNodes(p: Proof[SequentProofNode]): Int = {
+    var count = 0
+    for (n <- p.nodes)
+      if (!n.isInstanceOf[UnifyingResolution])
+        count = count + 1
+    count
+  }
+
+  def countFOSub(p: Proof[SequentProofNode]): Int = {
+    var count = 0
+    for (n <- p.nodes)
+      if (n.isInstanceOf[FOSubstitution])
+        count = count + 1
+    count
+  }
+
+  def countResolutionNodes(p: Proof[SequentProofNode]): Int = {
+    var count = 0
+    for (n <- p.nodes)
+      if (n.isInstanceOf[UnifyingResolution])
+        count = count + 1
+    count
+  }
+
+  def getProblems(file: String, path: String): MSet[String] = {
+    val outTj = MSet[String]()
+
+    for (line <- Source.fromFile(file).getLines()) {
+      val newProblemN = path + line
+      println(newProblemN)
+      outTj.add(newProblemN)
+    }
+    outTj
+  }
+
+  def main(args: Array[String]): Unit = {
+
+    val path = "/home/eze/Escritorio/Skeptik/GoodProofs/ALL/"
+    val proofList = "/home/eze/Escritorio/Skeptik/GoodProofs/ALL/list.txt"
+
+    val problemSetS = getProblems(proofList, path)
+    //    var errorCountT = 0
+    var totalCountT = 0
+
+    //    val elogger = new PrintWriter("errors.elog")
+    //    val eTypeLogger = new PrintWriter("errorTypes.elog")
+    //    val eProblemsLogger = new PrintWriter("errorProblems.elog")
+    val etempT = new PrintWriter("results-FOSplitting.log")
+    val header = "proof,compressed?,length,resOnlyLength,compressedLengthAll,compressedLengthResOnly,compressTime,compressRatio,compressSpeed,compressRatioRes,compressSpeedRes,numFOSub,totalTime"
+    etempT.println(header)
+    etempT.flush()
+    val noDataString = ",-1,-1,-1,-1,-1,-1,-1,-1,-1"
+
+    for (probY <- problemSetS) {
+      totalCountT = totalCountT + 1
+      try {
+
+        val preParseTime = System.nanoTime
+
+        println("Proof: " + probY)
+        val proofToTest = ProofParserSPASS.read(probY)
+        var variables   = ProofParserSPASS.getVars()
+        //ProofParserSPASS.cleanVars()
+        println("Variables: " + variables.mkString(","))
+        println(proofToTest)
+
+        val postParseTime = System.nanoTime
+
+        val proofLength = proofToTest.size
+        val numRes = countResolutionNodes(proofToTest)
+        val parseTime = postParseTime-preParseTime
+
+        val startTime = System.nanoTime
+
+        val timeout = 4000
+        val cottonSplit = new FOCottonSplit(variables,timeout)
+        val compressedProof = cottonSplit(proofToTest)
+        if(compressedProof.size < proofToTest.size) {
+          println("Proof after split: ")
+          println(compressedProof)
+        } else
+          println("The proof was not compressed\n\n#########################################\n\n")
+
+        if (compressedProof.root.conclusion.ant.nonEmpty || compressedProof.root.conclusion.suc.nonEmpty) {
+          etempT.println(probY.substring(path.length) + ",0," + proofLength + "," + numRes + noDataString + "-ERROR")
+          etempT.flush()
+        } else {
+
+          val endTime = System.nanoTime
+          val runTime = endTime - startTime
+          val compressedLengthAll = compressedProof.size
+          val compressedLengthResOnly = countResolutionNodes(compressedProof)
+
+          val compressionRatio = (proofLength - compressedLengthAll) / proofLength.toDouble
+          val compressionSpeed = (proofLength - compressedLengthAll) / runTime.toDouble
+
+          val compressionRatioRes = (numRes - compressedLengthResOnly) / proofLength.toDouble
+          val compressionSpeedRes = (numRes - compressedLengthResOnly) / runTime.toDouble
+
+          val numSub = countFOSub(compressedProof)
+
+          if (compressionRatioRes < 0) {
+            etempT.println(probY.substring(path.length) + ",0," + proofLength + "," + numRes + noDataString)
+            etempT.flush()
+          } else {
+
+            etempT.println(probY.substring(path.length) + ",1," + proofLength + "," + numRes + "," + compressedLengthAll + ","
+              + compressedLengthResOnly + "," + runTime + "," + compressionRatio + "," + compressionSpeed + "," + compressionRatioRes + "," + compressionSpeedRes+","+numSub+","+parseTime)
+            etempT.flush()
+          }
+        }
+      } catch {
+        case e: CompressionException => {
+          val proofToTest = ProofParserSPASS.read(probY)
+
+          val proofLength = proofToTest.size
+          val numRes = countResolutionNodes(proofToTest)
+
+          etempT.println(probY.substring(path.length) + ",0," + proofLength + "," + numRes + noDataString)
+          etempT.flush()
+        }
+      }
+
+    }
+
+    println("total: " + totalCountT)
+
+    //    elogger.flush
+    //    eTypeLogger.flush
+    //    eProblemsLogger.flush
+  }
+
+}

--- a/src/test/scala/at/logic/skeptik/algorithm/compressor/FOSplittingExperiment.scala
+++ b/src/test/scala/at/logic/skeptik/algorithm/compressor/FOSplittingExperiment.scala
@@ -12,7 +12,11 @@ import at.logic.skeptik.algorithm.compressor.FOSplit.FOCottonSplit
 
 import scala.io.Source
 
+object FOSplittingSetsContentionTests {
+  def main(args : Array[String]): Unit = {
 
+  }
+}
 /**
   * This object is created to
   */
@@ -92,7 +96,7 @@ object FOSplittingExperiment {
 
         val startTime = System.nanoTime
 
-        val timeout = 4000
+        val timeout = 500
         val cottonSplit = new FOCottonSplit(variables,timeout)
         val compressedProof = cottonSplit(proofToTest)
         val resNodesAfter = countResolutionNodes(compressedProof)

--- a/src/test/scala/at/logic/skeptik/algorithm/compressor/FOSplittingExperiment.scala
+++ b/src/test/scala/at/logic/skeptik/algorithm/compressor/FOSplittingExperiment.scala
@@ -12,13 +12,8 @@ import at.logic.skeptik.algorithm.compressor.FOSplit.FOCottonSplit
 
 import scala.io.Source
 
-object FOSplittingSetsContentionTests {
-  def main(args : Array[String]): Unit = {
-
-  }
-}
 /**
-  * This object is created to
+  * This object is created to run experiments with the FOSpliting Algorithm
   */
 object FOSplittingExperiment {
 
@@ -63,12 +58,8 @@ object FOSplittingExperiment {
     val proofList = "/home/eze/Escritorio/Skeptik/GoodProofs/ALL/list.txt"
 
     val problemSetS = getProblems(proofList, path)
-    //    var errorCountT = 0
     var totalCountT = 0
 
-    //    val elogger = new PrintWriter("errors.elog")
-    //    val eTypeLogger = new PrintWriter("errorTypes.elog")
-    //    val eProblemsLogger = new PrintWriter("errorProblems.elog")
     val etempT = new PrintWriter("results-FOSplitting.log")
     val header = "proof,compressed?,length,resOnlyLength,compressedLengthAll,compressedLengthResOnly,compressTime,compressRatio,compressSpeed,compressRatioRes,compressSpeedRes,numFOSub,totalTime"
     etempT.println(header)
@@ -84,7 +75,7 @@ object FOSplittingExperiment {
         println("Proof: " + probY)
         val proofToTest = ProofParserSPASS.read(probY)
         var variables   = ProofParserSPASS.getVars()
-        //ProofParserSPASS.cleanVars()
+
         println("Variables: " + variables.mkString(","))
         println(proofToTest)
 
@@ -148,14 +139,8 @@ object FOSplittingExperiment {
           etempT.flush()
         }
       }
-
     }
-
     println("total: " + totalCountT)
-
-    //    elogger.flush
-    //    eTypeLogger.flush
-    //    eProblemsLogger.flush
   }
 
 }

--- a/src/test/scala/at/logic/skeptik/algorithm/compressor/FOSplittingExperiment.scala
+++ b/src/test/scala/at/logic/skeptik/algorithm/compressor/FOSplittingExperiment.scala
@@ -95,11 +95,15 @@ object FOSplittingExperiment {
         val timeout = 4000
         val cottonSplit = new FOCottonSplit(variables,timeout)
         val compressedProof = cottonSplit(proofToTest)
-        if(compressedProof.size < proofToTest.size) {
-          println("Proof after split: ")
+        val resNodesAfter = countResolutionNodes(compressedProof)
+        if(resNodesAfter < numRes) {
+          println("Proof after split has "+ (numRes - resNodesAfter) + "less nodes resolution nodes")
           println(compressedProof)
-        } else
-          println("The proof was not compressed\n\n#########################################\n\n")
+        } else {
+          println("The proof was not compressed\n\n")
+          println(compressedProof)
+          println("\n\n#########################################\n\n")
+        }
 
         if (compressedProof.root.conclusion.ant.nonEmpty || compressedProof.root.conclusion.suc.nonEmpty) {
           etempT.println(probY.substring(path.length) + ",0," + proofLength + "," + numRes + noDataString + "-ERROR")

--- a/src/test/scala/at/logic/skeptik/algorithm/compressor/FOSplittingExperiment.scala
+++ b/src/test/scala/at/logic/skeptik/algorithm/compressor/FOSplittingExperiment.scala
@@ -96,7 +96,7 @@ object FOSplittingExperiment {
 
         val startTime = System.nanoTime
 
-        val timeout = 500
+        val timeout = 100
         val cottonSplit = new FOCottonSplit(variables,timeout)
         val compressedProof = cottonSplit(proofToTest)
         val resNodesAfter = countResolutionNodes(compressedProof)


### PR DESCRIPTION
This is the first version of the First Order generalization of the Splitting algorithm. Improvements can be made, e.g. we can search for better conditions to examine which literals can be used for splitting.

The current version still fails in some cases, it tries to split the proof on literals that produces two proofs that can't be resolved after the splitting procedure. This happens in rare cases, but it must be corrected.

There are tests in the files FOSplit.scala and FOCottonSplit.scala that shows examples of the algorithm working properly.
