### PR TITLE
Improvements to FO Splitting

### DIFF
--- a/src/main/scala/at/logic/skeptik/algorithm/compressor/FOSplit/FOCottonSplit.scala
+++ b/src/main/scala/at/logic/skeptik/algorithm/compressor/FOSplit/FOCottonSplit.scala
@@ -29,5 +29,5 @@ object FOCottonSplitTest {
   * @param timeout   A timeout parameter to stop the iterative splitting steps
   */
 class FOCottonSplit(override val variables : MSet[Var], val timeout: Int)
-extends FOSplit(variables) with FOAdditivityHeuristic with FORandomChoice with Timeout
+extends FOSplit(variables) with FOAdditivityHeuristic with FOHighestAdditivityChoise/*FORandomChoice*/ with Timeout
   with SetContentionAndSeenLiteralsHeuristic with NameEquality

--- a/src/main/scala/at/logic/skeptik/algorithm/compressor/FOSplit/FOCottonSplit.scala
+++ b/src/main/scala/at/logic/skeptik/algorithm/compressor/FOSplit/FOCottonSplit.scala
@@ -29,5 +29,5 @@ object FOCottonSplitTest {
   * @param timeout   A timeout parameter to stop the iterative splitting steps
   */
 class FOCottonSplit(override val variables : MSet[Var], val timeout: Int)
-extends FOSplit(variables) with FOAdditivityHeuristic with FOHighestAdditivityChoise/*FORandomChoice*/ with Timeout
+extends FOSplit(variables) with FOAdditivityHeuristic with FOHighestAdditivityChoise with Timeout
   with SetContentionAndSeenLiteralsHeuristic with NameEquality

--- a/src/main/scala/at/logic/skeptik/algorithm/compressor/FOSplit/FORandomChoice.scala
+++ b/src/main/scala/at/logic/skeptik/algorithm/compressor/FOSplit/FORandomChoice.scala
@@ -32,3 +32,13 @@ trait FORandomChoice extends AbstractFOSplitHeuristic {
     searchPos(randomLong(totalAdditivity) + 1)
   }
 }
+
+trait FOHighestAdditivityChoise {
+  def  chooseVariable(literalAdditivity: collection.Map[String,Long], totalAdditivity: Long) = {
+    def maxAdd(literal1: (String,Long), literal2 : (String,Long)) : (String,Long) =
+      if(literal1._2 > literal2._2) literal1 else literal2
+    val iterator = literalAdditivity.toIterator
+    if(iterator.isEmpty) None
+    else Some(Atom(iterator.reduceLeft(maxAdd)._1,Nil))
+  }
+}

--- a/src/main/scala/at/logic/skeptik/algorithm/compressor/FOSplit/FOSplit.scala
+++ b/src/main/scala/at/logic/skeptik/algorithm/compressor/FOSplit/FOSplit.scala
@@ -62,7 +62,7 @@ abstract class FOSplit(val variables : MSet[Var]) extends (Proof[Node] => Proof[
       def containsPos(sequent: SeqSequent, literal: E) : Boolean = seqContains(sequent.suc,literal)
       def containsNeg(sequent: SeqSequent, literal: E) : Boolean = seqContains(sequent.ant,literal)
       def contains(sequent: SeqSequent, literal: E) : Boolean = containsPos(sequent,literal) || containsNeg(sequent,literal)
-      def resolveAndUnifyNodes(leftNode : Node ,rightNode:Node) = //UnifyingResolution.resolve(leftNode,rightNode,variables)
+      def resolveAndUnifyNodes(leftNode : Node ,rightNode:Node) =
         UnifyingResolution.resolve(Contraction.contractIfPossible(leftNode,variables),Contraction.contractIfPossible(rightNode,variables),variables)
 
       require(fixedPremises.length == 2)

--- a/src/main/scala/at/logic/skeptik/algorithm/compressor/FOSplit/FOSplit.scala
+++ b/src/main/scala/at/logic/skeptik/algorithm/compressor/FOSplit/FOSplit.scala
@@ -64,6 +64,7 @@ abstract class FOSplit(val variables : MSet[Var]) extends (Proof[Node] => Proof[
       def containsNeg(sequent: SeqSequent, literal: E) : Boolean = seqContains(sequent.ant,literal)
       def contains(sequent: SeqSequent, literal: E) : Boolean = containsPos(sequent,literal) || containsNeg(sequent,literal)
       def resolveAndUnifyNodes(leftNode : Node ,rightNode:Node) = UnifyingResolution.resolve(leftNode,rightNode,variables)
+        //UnifyingResolution.resolve(Contraction.contractIfPossible(leftNode,variables),Contraction.contractIfPossible(rightNode,variables),variables)
 
       require(fixedPremises.length == 2)
       lazy val (fixedLeftPos  , fixedLeftNeg ) = fixedPremises.head
@@ -128,12 +129,8 @@ abstract class FOSplit(val variables : MSet[Var]) extends (Proof[Node] => Proof[
       val (left, right)   = split(p, selectedLiteral)
       val leftContracted  = Contraction.contractIfPossible(left, variables)
       val rightContracted = Contraction.contractIfPossible(right, variables)
-      try {
-        val compressedProof = UnifyingResolution.resolve(leftContracted, rightContracted, variables)
-        if (countResolutionNodes(compressedProof) < countResolutionNodes(p)) compressedProof else p
-      } catch {
-        case e : Exception => println("There was a problem to resolve the proofs after splitting!");p
-      }
+      val compressedProof = UnifyingResolution.resolve(leftContracted, rightContracted, variables)
+      if (countResolutionNodes(compressedProof) < countResolutionNodes(p)) compressedProof else p
     }
   }
 }

--- a/src/main/scala/at/logic/skeptik/algorithm/compressor/FOSplit/FOSplitHeuristic.scala
+++ b/src/main/scala/at/logic/skeptik/algorithm/compressor/FOSplit/FOSplitHeuristic.scala
@@ -12,7 +12,7 @@ import at.logic.skeptik.proof.sequent.{SequentProofNode => Node}
 
 import scala.collection.mutable.{HashMap => MMap, HashSet => MSet}
 
-object TestInclussion {
+object TestInclusion {
 
   protected def getLiteralName(literal: E) : String =
     literal match {
@@ -164,11 +164,11 @@ trait SeenLiteralsHeuristic extends AbstractFOSplitHeuristic {
       node match {
         case Axiom(_)          => ()
         case Contraction(_, _) => ()
-        case UnifyingResolution(_, _, leftResolvedLiteral, rightResolvedLiteral) => {
+        case UnifyingResolution(_, _, leftResolvedLiteral, rightResolvedLiteral) =>
           val literalName = getLiteralName(leftResolvedLiteral)
           val mgu         = MartelliMontanari((leftResolvedLiteral, rightResolvedLiteral) :: Nil)(this.variables) match {
             case Some(s) => s
-            case None    => throw new Exception("Resolved Literasl can't be unified: " + leftResolvedLiteral.toString + ", " + rightResolvedLiteral.toString)
+            case None    => throw new Exception("Resolved Literals can't be unified: " + leftResolvedLiteral.toString + ", " + rightResolvedLiteral.toString)
           }
           val unifiedLiteral = mgu(leftResolvedLiteral)
           if(literals.contains(literalName)) {
@@ -179,7 +179,6 @@ trait SeenLiteralsHeuristic extends AbstractFOSplitHeuristic {
           else
             literals += (literalName -> Some(unifiedLiteral))
           ()
-        }
       }
     }
     literals
@@ -310,7 +309,7 @@ trait SetContentionHeuristic extends AbstractFOSplitHeuristic {
       node match {
         case Axiom(_) => MSet[E]()
         case Contraction(premise, _) => nodesSets += premise -> nodesSets(node).clone() ; nodesSets(node).clone()
-        case UnifyingResolution(leftPremise, rightPremise, leftResolvedLiteral, rightResolvedLiteral) => {
+        case UnifyingResolution(leftPremise, rightPremise, leftResolvedLiteral, rightResolvedLiteral) =>
           val literalName = getLiteralName(leftResolvedLiteral)
           val mgu         = MartelliMontanari((leftResolvedLiteral, rightResolvedLiteral) :: Nil)(this.variables) match {
             case Some(s) => s
@@ -319,7 +318,7 @@ trait SetContentionHeuristic extends AbstractFOSplitHeuristic {
           val unifiedLiteral : E = mgu(leftResolvedLiteral)
           literals  += literalName  -> Some(unifiedLiteral)
           val leftSet = if(resultFromParents.isEmpty) MSet[E]() else resultFromParents.reduceLeft(_ intersect _)
-          nodesSets += leftPremise  -> (leftSet += unifiedLiteral)//(nodesSets(node).clone() += unifiedLiteral)
+          nodesSets += leftPremise  -> (leftSet += unifiedLiteral) //(nodesSets(node).clone() += unifiedLiteral)
           nodesSets += rightPremise -> nodesSets(leftPremise)
 
           val leftSeq = Sequent()(leftPremise.conclusion.ant ++ leftPremise.conclusion.suc :_*)
@@ -331,7 +330,6 @@ trait SetContentionHeuristic extends AbstractFOSplitHeuristic {
             literals += literalName -> None
 
           nodesSets(node).clone()
-        }
       }
     }
     literals
@@ -394,10 +392,9 @@ trait SetContentionAndSeenLiteralsHeuristic extends SetContentionHeuristic {
           nodesSets(n).clone()
         case (n @ UnifyingResolution(leftPremise, rightPremise, leftResolvedLiteral, rightResolvedLiteral)) :: Nil =>
           require(node == leftPremise || node == rightPremise)
-          val literalName = getLiteralName(leftResolvedLiteral)
           val mgu         = MartelliMontanari((leftResolvedLiteral, rightResolvedLiteral) :: Nil)(this.variables) match {
             case Some(s) => s
-            case None    => throw new Exception("Resolved Literasl can't be unified: " + leftResolvedLiteral.toString + ", " + rightResolvedLiteral.toString)
+            case None    => throw new Exception("Resolved Literals can't be unified: " + leftResolvedLiteral.toString + ", " + rightResolvedLiteral.toString)
           }
           val unifiedLiteral : E = mgu(leftResolvedLiteral)
           nodesSets(n).clone() += unifiedLiteral
@@ -406,10 +403,9 @@ trait SetContentionAndSeenLiteralsHeuristic extends SetContentionHeuristic {
           nodesSets(n).clone() intersect intersectionOfParentsSets(node,ns)
         case (n @ UnifyingResolution(leftPremise, rightPremise, leftResolvedLiteral, rightResolvedLiteral)) :: ns =>
           require(node == leftPremise || node == rightPremise)
-          val literalName = getLiteralName(leftResolvedLiteral)
           val mgu         = MartelliMontanari((leftResolvedLiteral, rightResolvedLiteral) :: Nil)(this.variables) match {
             case Some(s) => s
-            case None    => throw new Exception("Resolved Literasl can't be unified: " + leftResolvedLiteral.toString + ", " + rightResolvedLiteral.toString)
+            case None    => throw new Exception("Resolved Literals can't be unified: " + leftResolvedLiteral.toString + ", " + rightResolvedLiteral.toString)
           }
           val unifiedLiteral : E = mgu(leftResolvedLiteral)
           (nodesSets(n).clone() intersect intersectionOfParentsSets(node,ns)) += unifiedLiteral
@@ -441,7 +437,7 @@ trait SetContentionAndSeenLiteralsHeuristic extends SetContentionHeuristic {
       val literalName = getLiteralName(leftResolvedLiteral)
       val mgu         = MartelliMontanari((leftResolvedLiteral, rightResolvedLiteral) :: Nil)(this.variables) match {
         case Some(s) => s
-        case None    => throw new Exception("Resolved Literasl can't be unified: " + leftResolvedLiteral.toString + ", " + rightResolvedLiteral.toString)
+        case None    => throw new Exception("Resolved Literals can't be unified: " + leftResolvedLiteral.toString + ", " + rightResolvedLiteral.toString)
       }
       val unifiedLiteral : E = mgu(leftResolvedLiteral)
       if(literals.contains(literalName)) {
@@ -483,11 +479,10 @@ trait SetContentionAndSeenLiteralsHeuristic extends SetContentionHeuristic {
       node match {
         case Axiom(_) => checkInclusion(node,resultFromParents)
         case Contraction(premise, _) => checkInclusion(node,resultFromParents)
-        case UnifyingResolution(leftPremise, rightPremise, leftResolvedLiteral, rightResolvedLiteral) => {
+        case UnifyingResolution(leftPremise, rightPremise, leftResolvedLiteral, rightResolvedLiteral) =>
           checkLiteralRepetition(leftPremise, rightPremise, getLiteralName(leftResolvedLiteral))
           checkResolvedLiteralIsUnifiable(leftResolvedLiteral, rightResolvedLiteral)
           checkInclusion(node,resultFromParents)
-        }
       }
     }
     literals

--- a/src/main/scala/at/logic/skeptik/algorithm/compressor/FOSplit/FOSplitHeuristic.scala
+++ b/src/main/scala/at/logic/skeptik/algorithm/compressor/FOSplit/FOSplitHeuristic.scala
@@ -257,7 +257,7 @@ trait SetContentionHeuristic extends AbstractFOSplitHeuristic {
       }
 
 
-    val literals       = sequent.ant ++ sequent.suc
+    val literals = sequent.ant ++ sequent.suc
 
     if(literals.isEmpty && literalsSet.isEmpty) return true
 
@@ -321,18 +321,15 @@ trait SetContentionHeuristic extends AbstractFOSplitHeuristic {
           val leftSet = if(resultFromParents.isEmpty) MSet[E]() else resultFromParents.reduceLeft(_ intersect _)
           nodesSets += leftPremise  -> (leftSet += unifiedLiteral)//(nodesSets(node).clone() += unifiedLiteral)
           nodesSets += rightPremise -> nodesSets(leftPremise)
+
           val leftSeq = Sequent()(leftPremise.conclusion.ant ++ leftPremise.conclusion.suc :_*)
-          if(!isIncludedInSet(leftSeq,nodesSets(leftPremise))) {
+          if(!isIncludedInSet(leftSeq,nodesSets(leftPremise)))
             literals += literalName -> None
-            //println("Variables: " + variables.mkString(","))
-            //println("Left NOT included:\nPremise: " + leftPremise.conclusion.toString +"\nSet: " + nodesSets(leftPremise).mkString(","))
-          }
+
           val rightSeq = Sequent()(rightPremise.conclusion.ant ++ leftPremise.conclusion.suc :_*)
-          if(!isIncludedInSet(rightSeq,nodesSets(rightPremise))) {
+          if(!isIncludedInSet(rightSeq,nodesSets(rightPremise)))
             literals += literalName -> None
-            //println("Variables: " + variables.mkString(","))
-            //println("Right NOT included:\nPremise: " + rightPremise.conclusion.toString +"\nSet: " + nodesSets(rightPremise).mkString(","))
-          }
+
           nodesSets(node).clone()
         }
       }
@@ -435,11 +432,8 @@ trait SetContentionAndSeenLiteralsHeuristic extends SetContentionHeuristic {
     def checkInclusion(node : Node, parents : Seq[Node]) : Node = {
       nodesSets += node -> intersectionOfParentsSets(node,parents)
       val nodeSeq = Sequent()(node.conclusion.ant ++ node.conclusion.suc :_*)
-      if(!isIncludedInSet(nodeSeq,nodesSets(node))) {
-        println("NOT INCLUDED\nSequent: " + nodeSeq.toString + "\nSet: " + nodesSets(node).toString)
+      if(!isIncludedInSet(nodeSeq,nodesSets(node)))
         removeLiteralsResolvedWithNode(node, parents)
-      } else
-        println("INCLUDED\nSequent: " + nodeSeq.toString + "\nSet: " + nodesSets(node).toString)
       node
     }
 

--- a/src/main/scala/at/logic/skeptik/proof/sequent/resolution/Contraction.scala
+++ b/src/main/scala/at/logic/skeptik/proof/sequent/resolution/Contraction.scala
@@ -139,29 +139,6 @@ class Contraction(val premise: SequentProofNode, val desired: Sequent)(implicit 
   }
 
   def contract(seq: Sequent, subs: List[Substitution])(implicit unifiableVariables: MSet[Var]): (Seq[E], Seq[E], List[Substitution]) = {
-    def occurCheck(p: (E, E), u: Substitution): Boolean = {
-      val first = p._1
-      val second = p._2
-
-      for (sp <- u.toList) {
-        val v = sp._1
-        val e = sp._2
-        if (!e.isInstanceOf[Var]) {
-          if (getSetOfVars(first) contains v) {
-            //check if the second contains e
-            if (e.occursIn(second) && (getSetOfVars(e) contains v)) {
-              return false
-            }
-          } else if (getSetOfVars(second) contains v) {
-            if (e.occursIn(first) && (getSetOfVars(e) contains v)) {
-              return false
-            }
-          }
-        }
-      }
-
-      true
-    }
 
     def isUnifiable(p: (E, E))(implicit unifiableVariables: MSet[Var]) = unify(p :: Nil)(unifiableVariables) match {
       case None => false

--- a/src/main/scala/at/logic/skeptik/proof/sequent/resolution/UnifyingResolution.scala
+++ b/src/main/scala/at/logic/skeptik/proof/sequent/resolution/UnifyingResolution.scala
@@ -507,6 +507,7 @@ def findDesiredSequent(pairs: Seq[(E, E)], desired: Sequent, leftPremise: Sequen
 			rightPremise: SequentProofNode, leftPremiseClean: SequentProofNode, isMRR: Boolean, relaxation: Substitution = null)(implicit unifiableVariables: MSet[Var]): SequentProofNode = {
 
 		if (pairs.length == 0) {
+			println("Desired: " + desired +"\nleftPremise: " + leftPremise + "\nrightPremise: " + rightPremise)
 			throw new Exception("Resolution: Cannot find desired resolvent")
 		} else {
 

--- a/src/main/scala/at/logic/skeptik/proof/sequent/resolution/UnifyingResolution.scala
+++ b/src/main/scala/at/logic/skeptik/proof/sequent/resolution/UnifyingResolution.scala
@@ -83,11 +83,25 @@ object UnifyingResolution extends CanRenameVariables with FindDesiredSequent {
 	}
 
 	def resolve(leftPremise: SequentProofNode, rightPremise: SequentProofNode, unifiableVariables: MSet[Var]): UnifyingResolution = {
+		def applyManagingAmbiguity(leftPremise: SequentProofNode, rightPremise: SequentProofNode)(implicit unifiableVariables: MSet[Var]) = {
+
+			val leftPremiseClean = fixSharedNoFilter(leftPremise, rightPremise, 0, unifiableVariables)
+			val unifiablePairs = (for (auxL <- leftPremiseClean.conclusion.suc; auxR <- rightPremise.conclusion.ant) yield (auxL, auxR)).filter(isUnifiable)
+
+			if (unifiablePairs.length >= 1) {
+				val (auxL, auxR) = unifiablePairs(0)
+				new UnifyingResolution(leftPremise, rightPremise, auxL, auxR, leftPremiseClean, null)
+			} else if (unifiablePairs.length == 0) {
+				throw new Exception("Resolution: the conclusions of the given premises are not resolvable. B\nLeft premise: " + leftPremise.toString() +"\nRight premise: " + rightPremise.toString() + "\nVariables: " + unifiableVariables.mkString(","))
+			} else {
+				throw new Exception("Resolution: the resolvent is ambiguous.\nLeft premise: " + leftPremise.toString() +"\nRight premise: " + rightPremise.toString() + "\nVariables: " + unifiableVariables.mkString(","))
+			}
+		}
 		try {
-		  apply(leftPremise, rightPremise)(unifiableVariables)
+			applyManagingAmbiguity(leftPremise, rightPremise)(unifiableVariables)
 	  } catch {
 			case e: Exception =>
-				apply(rightPremise, leftPremise)(unifiableVariables)
+				applyManagingAmbiguity(rightPremise, leftPremise)(unifiableVariables)
 		}
 	}
 }
@@ -157,26 +171,15 @@ trait FindsVars extends checkUnifiableVariableName {
 trait CanRenameVariables extends FindsVars {
 
 	def occurCheck(p: (E, E), u: Substitution): Boolean = {
-		val first = p._1
-				val second = p._2
-
-				for (sp <- u.toList) {
-					val v = sp._1
-							val e = sp._2
-							if (!e.isInstanceOf[Var]) {
-								if (getSetOfVars(first) contains v) {
-									//check if the second contains e
-									if (e.occursIn(second) && (getSetOfVars(e) contains v)) {
-										return false
-									}
-								} else if (getSetOfVars(second) contains v) {
-									if (e.occursIn(first) && (getSetOfVars(e) contains v)) {
-										return false
-									}
-								}
-							}
+		for (sp <- u.toList) {
+			val v = sp._1
+			val e = sp._2
+			if (!e.isInstanceOf[Var]) {
+				if(getSetOfVars(e) contains v){
+					return false
 				}
-
+			}
+		}
 		true
 	}
 

--- a/src/test/scala/at/logic/skeptik/algorithm/compressor/FOSplittingExperiment.scala
+++ b/src/test/scala/at/logic/skeptik/algorithm/compressor/FOSplittingExperiment.scala
@@ -61,7 +61,7 @@ object FOSplittingExperiment {
     var totalCountT = 0
 
     //val etempT = new PrintWriter("results-FOSplitting.log")
-    val report = new PrintWriter("report-FOSplitting-try-5-no-amb.log")
+    val report = new PrintWriter("report-FOSplitting-try-8-no-repeated-literals-in-a-clause.log")
     //val header = "proof,compressed?,length,resOnlyLength,compressedLengthAll,compressedLengthResOnly,compressTime,compressRatio,compressSpeed,compressRatioRes,compressSpeedRes,numFOSub,totalTime"
     //etempT.println(header)
     //etempT.flush()
@@ -72,7 +72,7 @@ object FOSplittingExperiment {
       totalCountT = totalCountT + 1
       val preParseTime = System.nanoTime
 
-      report.println("Proof: " + probY)
+      report.println("Proof " + totalCountT + ": " + probY)
       val proofToTest = ProofParserSPASS.read(probY)
       var variables = ProofParserSPASS.getVars()
 
@@ -106,6 +106,7 @@ object FOSplittingExperiment {
           report.println("Variables: " + variables.mkString(","))
           report.println(proofToTest)
           report.println("There was a problem to resolve the proofs after splitting!\n" + e.toString)
+          report.println("\n\n#########################################\n\n")
       }
     }
         /*

--- a/src/test/scala/at/logic/skeptik/algorithm/compressor/FOSplittingExperiment.scala
+++ b/src/test/scala/at/logic/skeptik/algorithm/compressor/FOSplittingExperiment.scala
@@ -55,13 +55,13 @@ object FOSplittingExperiment {
   def main(args: Array[String]): Unit = {
 
     val path = "/home/eze/Escritorio/Skeptik/GoodProofs/ALL/"
-    val proofList = "/home/eze/Escritorio/Skeptik/GoodProofs/ALL/list2.txt"
+    val proofList = "/home/eze/Escritorio/Skeptik/GoodProofs/ALL/list.txt"
 
     val problemSetS = getProblems(proofList, path)
     var totalCountT = 0
 
     //val etempT = new PrintWriter("results-FOSplitting.log")
-    val report = new PrintWriter("report-FOSplitting-try-8-no-repeated-literals-in-a-clause.log")
+    val report = new PrintWriter("report-FOSplitting-10.log")
     //val header = "proof,compressed?,length,resOnlyLength,compressedLengthAll,compressedLengthResOnly,compressTime,compressRatio,compressSpeed,compressRatioRes,compressSpeedRes,numFOSub,totalTime"
     //etempT.println(header)
     //etempT.flush()

--- a/src/test/scala/at/logic/skeptik/algorithm/compressor/FOSplittingExperiment.scala
+++ b/src/test/scala/at/logic/skeptik/algorithm/compressor/FOSplittingExperiment.scala
@@ -55,7 +55,7 @@ object FOSplittingExperiment {
   def main(args: Array[String]): Unit = {
 
     val path = "/home/eze/Escritorio/Skeptik/GoodProofs/ALL/"
-    val proofList = "/home/eze/Escritorio/Skeptik/GoodProofs/ALL/list.txt"
+    val proofList = "/home/eze/Escritorio/Skeptik/GoodProofs/ALL/list2.txt"
 
     val problemSetS = getProblems(proofList, path)
     var totalCountT = 0
@@ -107,6 +107,7 @@ object FOSplittingExperiment {
           report.println(proofToTest)
           report.println("There was a problem to resolve the proofs after splitting!\n" + e.toString)
           report.println("\n\n#########################################\n\n")
+          report.flush()
       }
     }
         /*

--- a/src/test/scala/at/logic/skeptik/algorithm/compressor/FOSplittingExperiment.scala
+++ b/src/test/scala/at/logic/skeptik/algorithm/compressor/FOSplittingExperiment.scala
@@ -60,46 +60,55 @@ object FOSplittingExperiment {
     val problemSetS = getProblems(proofList, path)
     var totalCountT = 0
 
-    val etempT = new PrintWriter("results-FOSplitting.log")
-    val header = "proof,compressed?,length,resOnlyLength,compressedLengthAll,compressedLengthResOnly,compressTime,compressRatio,compressSpeed,compressRatioRes,compressSpeedRes,numFOSub,totalTime"
-    etempT.println(header)
-    etempT.flush()
+    //val etempT = new PrintWriter("results-FOSplitting.log")
+    val report = new PrintWriter("report-FOSplitting-try-5-no-amb.log")
+    //val header = "proof,compressed?,length,resOnlyLength,compressedLengthAll,compressedLengthResOnly,compressTime,compressRatio,compressSpeed,compressRatioRes,compressSpeedRes,numFOSub,totalTime"
+    //etempT.println(header)
+    //etempT.flush()
     val noDataString = ",-1,-1,-1,-1,-1,-1,-1,-1,-1"
 
     for (probY <- problemSetS) {
+
       totalCountT = totalCountT + 1
+      val preParseTime = System.nanoTime
+
+      report.println("Proof: " + probY)
+      val proofToTest = ProofParserSPASS.read(probY)
+      var variables = ProofParserSPASS.getVars()
+
+      val postParseTime = System.nanoTime
+
+      val proofLength = proofToTest.size
+      val numRes = countResolutionNodes(proofToTest)
+      val parseTime = postParseTime - preParseTime
+
+      val startTime = System.nanoTime
+
+      val timeout = 10
+      val cottonSplit = new FOCottonSplit(variables, timeout)
       try {
-
-        val preParseTime = System.nanoTime
-
-        println("Proof: " + probY)
-        val proofToTest = ProofParserSPASS.read(probY)
-        var variables   = ProofParserSPASS.getVars()
-
-        println("Variables: " + variables.mkString(","))
-        println(proofToTest)
-
-        val postParseTime = System.nanoTime
-
-        val proofLength = proofToTest.size
-        val numRes = countResolutionNodes(proofToTest)
-        val parseTime = postParseTime-preParseTime
-
-        val startTime = System.nanoTime
-
-        val timeout = 100
-        val cottonSplit = new FOCottonSplit(variables,timeout)
         val compressedProof = cottonSplit(proofToTest)
+
         val resNodesAfter = countResolutionNodes(compressedProof)
-        if(resNodesAfter < numRes) {
-          println("Proof after split has "+ (numRes - resNodesAfter) + "less nodes resolution nodes")
-          println(compressedProof)
+        if (resNodesAfter < numRes) {
+          report.println("Proof after split has " + (numRes - resNodesAfter) + " less resolution node(s)")
+          report.println(proofToTest)
+          report.println(compressedProof)
         } else {
-          println("The proof was not compressed\n\n")
-          println(compressedProof)
-          println("\n\n#########################################\n\n")
+          report.println("The proof was not compressed\n\n")
+          //println(compressedProof)
+          report.println("\n\n#########################################\n\n")
         }
 
+        report.flush()
+      } catch {
+        case e: Exception =>
+          report.println("Variables: " + variables.mkString(","))
+          report.println(proofToTest)
+          report.println("There was a problem to resolve the proofs after splitting!\n" + e.toString)
+      }
+    }
+        /*
         if (compressedProof.root.conclusion.ant.nonEmpty || compressedProof.root.conclusion.suc.nonEmpty) {
           etempT.println(probY.substring(path.length) + ",0," + proofLength + "," + numRes + noDataString + "-ERROR")
           etempT.flush()
@@ -141,6 +150,6 @@ object FOSplittingExperiment {
       }
     }
     println("total: " + totalCountT)
+    */
   }
-
 }

--- a/src/test/scala/at/logic/skeptik/algorithm/compressor/FOSplittingExperiment.scala
+++ b/src/test/scala/at/logic/skeptik/algorithm/compressor/FOSplittingExperiment.scala
@@ -84,7 +84,7 @@ object FOSplittingExperiment {
 
       val startTime = System.nanoTime
 
-      val timeout = 10
+      val timeout = 1
       val cottonSplit = new FOCottonSplit(variables, timeout)
       try {
         val compressedProof = cottonSplit(proofToTest)


### PR DESCRIPTION
A new heuristic to filter nodes was added. Now if a literal is repeated (with the same sign) in a node the heuristic does not allow to choose that node for splitting.
A bug in Contraction constructor was detected and fixed
A bug in the method that checked sequents inclusion in a set modulus a substitution was detected and the method was re-implemented from scratch.
Experimentation still shows imperfections as some proofs still fail raising an exception.
