### PR TITLE
Splitting algorithm review

### DIFF
--- a/src/main/scala/at/logic/skeptik/algorithm/compressor/FOSplit/EPFOSplit.scala
+++ b/src/main/scala/at/logic/skeptik/algorithm/compressor/FOSplit/EPFOSplit.scala
@@ -1,0 +1,286 @@
+package at.logic.skeptik.algorithm.compressor.FOSplit
+
+import at.logic.skeptik.algorithm.compressor.Timeout
+import at.logic.skeptik.algorithm.unifier.MartelliMontanari
+import at.logic.skeptik.expression.formula.Atom
+import at.logic.skeptik.expression.substitution.immutable.Substitution
+import at.logic.skeptik.expression.term.FunctionTerm
+import at.logic.skeptik.expression.{Abs, App, AppRec, E, Var, i}
+import at.logic.skeptik.judgment.immutable.{SeqSequent => Sequent}
+import at.logic.skeptik.proof.Proof
+import at.logic.skeptik.proof.sequent.lk.Axiom
+import at.logic.skeptik.proof.sequent.resolution.{Contraction, UnifyingResolution}
+import at.logic.skeptik.proof.sequent.{SequentProofNode => Node}
+
+import scala.collection.mutable.{HashMap => MMap, HashSet => MSet}
+
+/**
+  * In this version of FO Splitting we will not split over all occurrences of a literal.
+  * Instead if we select one instance of a literal for splitting we will split over it and
+  * all the alpha equivalent occurrences of it.
+  */
+class EPFOSplit(override val variables : collection.mutable.Set[Var], val timeout : Int)
+extends FOSplit(variables) with EPFOAdditivityHeuristic with EPFOHighestAdditivityChoice with Timeout
+with IndependentVariablesHeuristic with AlphaEquivalenceAsEquality {
+}
+
+
+trait AbstractEPFOSplitHeuristic extends FOSplit {
+  protected def getLiteralName(literal: E) : String =
+    literal match {
+      case Atom(Var(name,_),_) => name
+      case App(function,arg)   => getLiteralName(function)
+      case Var(name,_)         => name
+      case _                   => throw new Exception("Literal name not found: " + literal.toString)
+    }
+
+  def computeMeasures(proof: Proof[Node]): (MMap[E,Long],Long)
+
+  def chooseVariable(literalAdditivity: collection.Map[E,Long], totalAdditivity: Long): Option[E]
+
+  def selectLiteral(proof: Proof[Node]) = {
+    val (measureMap, measureSum) = computeMeasures(proof)
+    chooseVariable(measureMap, measureSum)
+  }
+}
+
+trait EPFOAdditivityHeuristic extends AbstractEPFOSplitHeuristic  {
+
+  def computeMeasures(proof: Proof[Node]) = {
+    var totalAdditivity = 0.toLong
+    val literalAdditivity = MMap[E,Long]()
+    def visit(node: Node) = node match {
+      case UnifyingResolution(_,_,leftResolveLiteral,rightResolveLiteral) =>
+        val nodeAdditivity = ((node.conclusion.size - (node.premises.head.conclusion.size max node.premises(1).conclusion.size)) max 0) + 1
+        totalAdditivity += nodeAdditivity
+        literalAdditivity.update(leftResolveLiteral,literalAdditivity.getOrElse(leftResolveLiteral,0.toLong) + nodeAdditivity)
+      case _ =>
+    }
+    proof.foreach(visit)
+    (literalAdditivity, totalAdditivity)
+  }
+}
+
+
+
+trait EPFOHighestAdditivityChoice extends AbstractEPFOSplitHeuristic {
+  def chooseVariable(literalAdditivity: collection.Map[E, Long], totalAdditivity: Long) = {
+    def maxAdd(literal1: (E, Long), literal2 : (E, Long)): (E, Long) =
+      if (literal1._2 > literal2._2) literal1 else literal2
+    val iterator = literalAdditivity.toIterator
+    if (iterator.isEmpty) None
+    else Some(iterator.reduceLeft(maxAdd)._1)
+  }
+}
+
+
+trait IndependentVariablesHeuristic extends AbstractEPFOSplitHeuristic {
+
+  def isIncludedInSet(sequent: Sequent, literalsSet : MSet[E]): Boolean = {
+    val constantPrefix = "converted_to_constant_"
+    def convertVariablesIntoNewConstants(e: E): E =
+      e match {
+        case Var(name, typ) => if (Character.isUpperCase(name.charAt(0))) Var(constantPrefix + name, typ) else Var(name, typ)
+        case App(fun, arg) => App(convertVariablesIntoNewConstants(fun), convertVariablesIntoNewConstants(arg))
+        case Abs(x, body) => Abs(convertVariablesIntoNewConstants(x).asInstanceOf[Var], convertVariablesIntoNewConstants(body))
+      }
+
+    def createCompatibleSubstitution(restriction : MMap[Var,E],subs: List[List[Substitution]]): List[Substitution] =
+      subs match {
+        case Nil      => List(Substitution(restriction.toList :_*))
+        case x :: xs  =>
+          x flatMap { s =>
+            val newRestrictions = restriction.clone()
+            val pairs           = s.iterator
+            var satissfyRestrictions = true
+            for((v,e) <- pairs) {
+              if (!(newRestrictions contains v))
+                newRestrictions += (v -> e)
+              else if (newRestrictions(v) != e)
+                satissfyRestrictions = false
+            }
+            if(satissfyRestrictions) createCompatibleSubstitution(newRestrictions,xs)
+            else Nil
+          }
+      }
+
+
+    val literals = sequent.ant ++ sequent.suc
+
+    if(literals.isEmpty && literalsSet.isEmpty) return true
+
+    // We first convert all variables in the literals set to constants so we can calculate substitutions
+    // that only act on the literals that come from the sequent
+    val literalSetWithoutVariables = literalsSet.map(convertVariablesIntoNewConstants)
+
+    // Now, for each literal we calculate the occurrences of a literal with the same name in the set
+    // Note that a literal like q(X) may have more than one occurrence in the set, e.g. q(a),q(converted_to_constant_X)
+    val occurrences: MMap[E, List[E]] = MMap[E, List[E]]()
+    for (l <- literals)
+      occurrences += (l -> literalSetWithoutVariables.filter(getLiteralName(_) == getLiteralName(l)).toList)
+
+    val literalSubstitutions: MMap[E, List[Substitution]] =
+      occurrences map {
+        case (e1, ls) =>
+          e1 -> ls.map(x => MartelliMontanari((e1, x) :: Nil)(this.variables)).filter(_.nonEmpty).map(_.get)
+      }
+
+    // If we find a literal that can't be included in the
+    // set we know that the whole set won't be contained
+    for (l <- literals)
+      if (literalSubstitutions(l).isEmpty) return false
+
+    val substitutionByLiteralName = MMap[String,List[Substitution]]()
+    val literalsNames = literalSubstitutions.keySet.map(getLiteralName)
+    for(l <- literalsNames) {
+      val substitutionsToCompare = literalSubstitutions.filter({case (k, v) => getLiteralName(k) == l}).values.toList
+      substitutionByLiteralName += (l -> createCompatibleSubstitution(MMap[Var,E](),substitutionsToCompare))
+    }
+
+    // And we repeat the process with the substitutions of each literalName
+    val substitutions = createCompatibleSubstitution(MMap[Var,E](),substitutionByLiteralName.values.toList)
+    if(substitutions.isEmpty)
+      false
+    else {
+      val randomSub = substitutions.head // Any substitution of the list should be fine
+      (literals map {x => randomSub(x)}).toSet subsetOf literalSetWithoutVariables
+    }
+  }
+
+
+  def exploreLiterals(proof: Proof[Node]) : MMap[E,Option[E]] = {
+    val literals = MMap[E, Option[E]]()
+    val nodesSets = MMap[Node, MSet[E]]()
+
+    nodesSets +=  proof.root -> MSet[E](proof.root.conclusion.ant ++ proof.root.conclusion.suc :_* )
+
+
+    def intersectionOfParentsSets(node : Node, parents : Seq[Node]) : MSet[E] = {
+      parents match {
+        case Nil =>
+          require(node == proof.root)
+          MSet[E]().clone()
+        case (n @ Contraction(premise,_)) :: Nil =>
+          require(node == premise)
+          nodesSets(n).clone()
+        case (n @ UnifyingResolution(leftPremise, rightPremise, leftResolvedLiteral, rightResolvedLiteral)) :: Nil =>
+          require(node == leftPremise || node == rightPremise)
+          val mgu         = MartelliMontanari((leftResolvedLiteral, rightResolvedLiteral) :: Nil)(this.variables) match {
+            case Some(s) => s
+            case None    => throw new Exception("Resolved Literals can't be unified: " + leftResolvedLiteral.toString + ", " + rightResolvedLiteral.toString)
+          }
+          val unifiedLiteral : E = mgu(leftResolvedLiteral)
+          nodesSets(n).clone() += unifiedLiteral
+        case (n @ Contraction(premise,_)) :: ns  =>
+          require(node == premise)
+          nodesSets(n).clone() intersect intersectionOfParentsSets(node,ns)
+        case (n @ UnifyingResolution(leftPremise, rightPremise, leftResolvedLiteral, rightResolvedLiteral)) :: ns =>
+          require(node == leftPremise || node == rightPremise)
+          val mgu         = MartelliMontanari((leftResolvedLiteral, rightResolvedLiteral) :: Nil)(this.variables) match {
+            case Some(s) => s
+            case None    => throw new Exception("Resolved Literals can't be unified: " + leftResolvedLiteral.toString + ", " + rightResolvedLiteral.toString)
+          }
+          val unifiedLiteral : E = mgu(leftResolvedLiteral)
+          (nodesSets(n).clone() intersect intersectionOfParentsSets(node,ns)) += unifiedLiteral
+      }
+    }
+
+    def removeLiteralsResolvedWithNode(node : Node, parents : Seq[Node]): Unit = {
+      parents match {
+        case Nil =>
+        case UnifyingResolution(leftPremise, rightPremise, leftResolvedLiteral, rightResolvedLiteral) :: ns =>
+          require(node == leftPremise || node == rightPremise)
+          if(node == leftPremise)
+            literals += leftResolvedLiteral  -> None
+          else
+            literals += rightResolvedLiteral -> None
+          removeLiteralsResolvedWithNode(node,ns)
+        case _ :: ns =>
+          removeLiteralsResolvedWithNode(node,ns)
+      }
+    }
+
+    def checkInclusion(node : Node, parents : Seq[Node]) : Node = {
+      nodesSets += node -> intersectionOfParentsSets(node,parents)
+      val nodeSeq = Sequent()(node.conclusion.ant ++ node.conclusion.suc :_*)
+      if(!isIncludedInSet(nodeSeq,nodesSets(node)))
+        removeLiteralsResolvedWithNode(node, parents)
+      node
+    }
+
+
+
+
+
+    def getVars(literal : E) : MSet[Var] =
+      literal match {
+        case Atom(_,terms)   => if(terms.isEmpty) MSet[Var]() else if(terms.size == 1) getVarsFromTerms(terms.head) else (terms map getVarsFromTerms) reduce (_ union _)
+        case App(App(p,x),y) => getVars(App(p,x)) union getVarsFromTerms(y)
+        case App(x,y)        =>
+          require(x.t != i)
+          getVarsFromTerms(y)
+        case Var(_,_)        =>
+          println("xcxzcz")
+          MSet[Var]()
+      }
+    def getVarsFromTerms(term : E) : MSet[Var] = {
+      term match {
+        case FunctionTerm(_,args) => if(args.isEmpty) MSet[Var]() else if(args.size == 1) getVarsFromTerms(args.head) else (args map getVarsFromTerms) reduce (_ union _)
+        case v @ Var(_,_)         => if(this.variables contains v) MSet[Var](v) else MSet[Var]()
+        case AppRec(_,args)       => if(args.isEmpty) MSet[Var]() else if(args.size == 1) getVarsFromTerms(args.head) else (args map getVarsFromTerms) reduce (_ union _)
+        case App(App(f,x),y)      => getVarsFromTerms(App(f,x)) union getVars(y)
+        case App(f,y)             => getVarsFromTerms(y)
+      }
+    }
+
+    def shareVariables(lit : E, premise : Node) : Boolean = {
+      val premiseWithoutLit = (lit -: premise.conclusion) - lit
+      val litVars = getVars(lit)
+      val premiseLiteralsVars = (premiseWithoutLit.ant ++ premiseWithoutLit.suc) map getVars
+      val premiseWithoutLitVars = if(premiseLiteralsVars.isEmpty) MSet[Var]() else if(premiseLiteralsVars.size == 1) premiseLiteralsVars.head else  premiseLiteralsVars reduce (_ union _)
+      (litVars intersect premiseWithoutLitVars).nonEmpty
+    }
+
+    def update(lit : E, premise : Node) : Unit =
+      if((literals contains lit)
+        && shareVariables(lit,premise))
+        literals += lit -> None
+      else if((literals contains lit)
+        && ! shareVariables(lit,premise))
+        ()
+      else if(shareVariables(lit,premise))
+        literals += lit -> None
+      else literals += lit -> Some(lit)
+
+    proof bottomUp { (node: Node, resultFromParents : Seq[Node]) =>
+      node match {
+        case UnifyingResolution(leftPremise, rightPremise, leftResolvedLiteral, rightResolvedLiteral) =>
+          update(leftResolvedLiteral,leftPremise)
+          update(rightResolvedLiteral,rightPremise)
+          checkInclusion(node,resultFromParents)
+        case Axiom(sequent) =>
+          sequent.ant.foreach(x => update(x,node))
+          sequent.suc.foreach(x => update(x,node))
+          checkInclusion(node,resultFromParents)
+        case _ => checkInclusion(node,resultFromParents)
+      }
+    }
+    literals
+  }
+
+  def availableLiterals(literals : MMap[E,Option[E]]) : MSet[E] = {
+    val available = literals.filter(_._2.nonEmpty)
+    MSet(available.keys.toList: _*)
+  }
+
+  def computeMeasures(proof: Proof[Node]): (MMap[E,Long],Long)
+
+  def chooseVariable(literalAdditivity: collection.Map[E,Long], totalAdditivity: Long): Option[E]
+
+  override def selectLiteral(proof: Proof[Node]) = {
+    val (measureMap, measureSum) = computeMeasures(proof)
+    val literals : MSet[E] = availableLiterals(exploreLiterals(proof))
+    val availableLiteralsMap = measureMap.filter(x => literals.contains(x._1))
+    chooseVariable(availableLiteralsMap, measureSum)
+  }
+}

--- a/src/main/scala/at/logic/skeptik/algorithm/compressor/FOSplit/FOCottonSplit.scala
+++ b/src/main/scala/at/logic/skeptik/algorithm/compressor/FOSplit/FOCottonSplit.scala
@@ -29,5 +29,5 @@ object FOCottonSplitTest {
   * @param timeout   A timeout parameter to stop the iterative splitting steps
   */
 class FOCottonSplit(override val variables : MSet[Var], val timeout: Int)
-extends FOSplit(variables) with FOAdditivityHeuristic with FOHighestAdditivityChoise with Timeout
+extends FOSplit(variables) with FOAdditivityHeuristic with FOHighestAdditivityChoice with Timeout
   with SetContentionAndSeenLiteralsHeuristic with NameEquality

--- a/src/main/scala/at/logic/skeptik/algorithm/compressor/FOSplit/FORandomChoice.scala
+++ b/src/main/scala/at/logic/skeptik/algorithm/compressor/FOSplit/FORandomChoice.scala
@@ -33,8 +33,8 @@ trait FORandomChoice extends AbstractFOSplitHeuristic {
   }
 }
 
-trait FOHighestAdditivityChoise {
-  def  chooseVariable(literalAdditivity: collection.Map[String,Long], totalAdditivity: Long) = {
+trait FOHighestAdditivityChoice {
+  def chooseVariable(literalAdditivity: collection.Map[String,Long], totalAdditivity: Long) = {
     def maxAdd(literal1: (String,Long), literal2 : (String,Long)) : (String,Long) =
       if(literal1._2 > literal2._2) literal1 else literal2
     val iterator = literalAdditivity.toIterator

--- a/src/main/scala/at/logic/skeptik/algorithm/compressor/FOSplit/FOSplit.scala
+++ b/src/main/scala/at/logic/skeptik/algorithm/compressor/FOSplit/FOSplit.scala
@@ -42,9 +42,12 @@ abstract class FOSplit(val variables : MSet[Var]) extends (Proof[Node] => Proof[
 
   def split(proof: Proof[Node], selectedLiteral : E): (Node,Node) = {
     def manageContraction(node : Node, fixedPremises : Seq[(Node,Node)]) : (Node , Node) = {
+      def contract(premise : Node, vars : MSet[Var]) : Node =
+          Contraction.contractIfPossible(premise,vars)
+
       require(fixedPremises.length == 1)
       val (left,right) = fixedPremises.head
-      (Contraction.contractIfPossible(left,variables),Contraction.contractIfPossible(right,variables))
+      (contract(left,variables),contract(right,variables))
     }
 
     def manageResolution(node : Node ,fixedPremises : Seq[(Node,Node)]) : (Node,Node) = {
@@ -113,6 +116,7 @@ abstract class FOSplit(val variables : MSet[Var]) extends (Proof[Node] => Proof[
           else if(containsNeg(leftConclusionNeg,leftResolvedLiteral) && containsPos(rightConclusionNeg,rightResolvedLiteral))
             resolveAndUnifyNodes(fixedLeftNeg,fixedRightNeg,node.conclusion)
           else fixedRightNeg // This is arbitrary
+
         (finalLeftProof,finalRighttProof)
       }
     }
@@ -142,6 +146,7 @@ abstract class FOSplit(val variables : MSet[Var]) extends (Proof[Node] => Proof[
         //println("Selected Literal: " + selectedLiteral)
         val (left, right)   = split(p, selectedLiteral)
         //println("Left: " + Proof(left))
+        //println()
         //println("Right: " + Proof(right))
         val leftContracted  = Contraction.contractIfPossible(left, variables)
         val rightContracted = Contraction.contractIfPossible(right, variables)

--- a/src/main/scala/at/logic/skeptik/algorithm/compressor/FOSplit/FOSplit.scala
+++ b/src/main/scala/at/logic/skeptik/algorithm/compressor/FOSplit/FOSplit.scala
@@ -182,4 +182,6 @@ object FOSplittingUtils {
     TestInclusion.isIncludedInSet(node.conclusion,literals,vars)
   }
 
+  def isMoreGeneralOrEqual(literal1 : E, literal2 : E, vars : MSet[Var]) : Boolean =
+    isMoreGeneralOrEqual(Axiom(SeqSequent()(literal1)),Axiom(SeqSequent()(literal2)),vars)
 }

--- a/src/main/scala/at/logic/skeptik/algorithm/compressor/FOSplit/FOSplitHeuristic.scala
+++ b/src/main/scala/at/logic/skeptik/algorithm/compressor/FOSplit/FOSplitHeuristic.scala
@@ -22,7 +22,7 @@ object TestInclusion {
       case _                   => throw new Exception("Literal name not found: " + literal.toString)
     }
 
-  protected def isIncludedInSet(sequent: Sequent, literalsSet : MSet[E]): Boolean = {
+  def isIncludedInSet(sequent: Sequent, literalsSet : MSet[E], variables : collection.mutable.Set[Var]): Boolean = {
 
     val literals = sequent.ant ++ sequent.suc
 
@@ -50,7 +50,7 @@ object TestInclusion {
     val literalSubstitutions: MMap[E, List[Substitution]] =
       occurrences map {
         case (e1, ls) =>
-          e1 -> ls.map(x => MartelliMontanari((e1, x) :: Nil)(MSet(Var("U",i),Var("V",i),Var("W",i)))).filter(_.nonEmpty).map(_.get)
+          e1 -> ls.map(x => MartelliMontanari((e1, x) :: Nil)(variables)).filter(_.nonEmpty).map(_.get)
       }
 
     // If we find a literal that can't be included in the
@@ -65,15 +65,15 @@ object TestInclusion {
           x flatMap { s =>
             val newRestrictions = restriction.clone()
             val pairs           = s.iterator
-            var flag = false
+            var satissfyRestrictions = true
             for((v,e) <- pairs) {
               if (!(newRestrictions contains v))
                 newRestrictions += (v -> e)
               else if (newRestrictions(v) != e)
-                flag = true
+                satissfyRestrictions = false
             }
-            if(flag) Nil
-            else createCompatibleSubstitution(newRestrictions,xs)
+            if(satissfyRestrictions) createCompatibleSubstitution(newRestrictions,xs)
+            else Nil
           }
       }
 
@@ -98,7 +98,9 @@ object TestInclusion {
   def main(args: Array[String]) = {
     val testSeq = Sequent()(List(Atom("p3", List(Var("U", i), Var("W", i))), Atom("p3", List(Var("U", i), Var("V", i))), Atom("p3", List(Var("W", i), Var("V", i)))): _*)
     val testSet = MSet(Atom("p3", List(Var("V", i), Var("V", i))), Atom("p3", List(Var("c21", i), Var("c19", i))), Atom("p3", List(Var("c19", i), Var("c21", i))))
-    println(isIncludedInSet(testSeq, testSet))
+    val s = Sequent(Atom("q",List(Var("V136",i))))(Atom("p",List(Var("a",i))))
+    val set = MSet(Atom("q",List(Var("Z",i))),Atom("p",List(Var("a",i))))
+    println(isIncludedInSet(s, set,MSet(Var("V136",i),Var("Z",i))))
   }
 }
 

--- a/src/main/scala/at/logic/skeptik/algorithm/compressor/FOSplit/LiteralsEquality.scala
+++ b/src/main/scala/at/logic/skeptik/algorithm/compressor/FOSplit/LiteralsEquality.scala
@@ -27,3 +27,12 @@ trait NameEquality extends AbstractEquality {
       case _                                              => throw new Exception("The literal is not an instance of an Atom\nLiterals: " + selectedLiteral.toString + ", " + nodeLiteral.toString)
     }
 }
+
+trait AlphaEquivalenceAsEquality extends AbstractEquality {
+  def equalLiterals(selectedLiteral: E, nodeLiteral: E): Boolean =
+    (FOSplittingUtils.isMoreGeneralOrEqual(selectedLiteral,nodeLiteral,this.variables)
+    && FOSplittingUtils.isMoreGeneralOrEqual(nodeLiteral,selectedLiteral,this.variables))
+
+
+}
+

--- a/src/main/scala/at/logic/skeptik/parser/TPTPParsers/ProofParserCNFTPTP.scala
+++ b/src/main/scala/at/logic/skeptik/parser/TPTPParsers/ProofParserCNFTPTP.scala
@@ -49,6 +49,17 @@ extends BaseParserTPTP {
     p
   }
 
+  def extractFromString(file : String) : Proof[Node] = {
+    val p =
+      phrase(proof)(new lexical.Scanner(file)) match {
+        case Success(p2, _) => p2
+        case Error(message, _) => throw new Exception("Error: " + message)
+        case Failure(message, _) => throw new Exception("Failure: " + message)
+      }
+    reset()
+    p
+  }
+
   ////////////////////////////////////////////////////////////////////
   // Proof generation
   ////////////////////////////////////////////////////////////////////

--- a/src/test/scala/at/logic/skeptik/algorithm/FOProofsGenerator/ProofGeneratorTests.scala
+++ b/src/test/scala/at/logic/skeptik/algorithm/FOProofsGenerator/ProofGeneratorTests.scala
@@ -22,7 +22,7 @@ object ProofGeneratorTests {
   def main(arfs : Array[String]) : Unit = {
     //testContraction()
     //randomLiteralTest()
-    compressionTests(1000,7,1000)
+    compressionTests(1000,7,1)
     //tests(1000,7,1)
     //f()
   }
@@ -124,6 +124,7 @@ object ProofGeneratorTests {
     var splAv     = 0.0
     var rpiAv     = 0.0
     var splitFail = 0
+    var rpiFail   = 0
     for(i <- 1 to proofN) {
       val (proof, vars) = proofGenerationTest(height,Sequent()())
       proofsLenghtsSum += proof.size
@@ -149,6 +150,8 @@ object ProofGeneratorTests {
       if (countResolutionNodes(proof) > countResolutionNodes(rpiCompressedProof)
         && countResolutionNodes(rpiCompressedProof) > countResolutionNodes(proof) / 2) {
         rpiN += 1
+        if(rpiCompressedProof.root.conclusion.ant.nonEmpty || rpiCompressedProof.root.conclusion.suc.nonEmpty)
+          rpiFail += 1
         rpiProofsLenghtsSum += rpiCompressedProof.size
         rpiAv += (countResolutionNodes(rpiCompressedProof) * 1.0) / countResolutionNodes(proof)
         println("FORPI: " + countResolutionNodes(proof) + " -> " + countResolutionNodes(rpiCompressedProof))
@@ -176,6 +179,7 @@ object ProofGeneratorTests {
     println("Number of fails: " + splitFail)
     println("FORPI\nReduced: " + rpiN + " proof(s)\nFailed in: " + rpiF + " proof(s)\nThe average compression was to " + rpiAv/rpiN)
     println("Total compression ratio: " + ((proofsLenghtsSum - rpiProofsLenghtsSum)*1.0)/proofsLenghtsSum)
+    println("Number of fails: " + rpiFail)
   }
 
   def testContraction() = {

--- a/src/test/scala/at/logic/skeptik/algorithm/FOProofsGenerator/ProofGeneratorTests.scala
+++ b/src/test/scala/at/logic/skeptik/algorithm/FOProofsGenerator/ProofGeneratorTests.scala
@@ -2,6 +2,7 @@ package at.logic.skeptik.algorithm.FOProofsGenerator
 
 import at.logic.skeptik.algorithm.compressor.{FOLowerUnits, FORecyclePivotsWithIntersection}
 import at.logic.skeptik.algorithm.compressor.FOSplit.FOCottonSplit
+import at.logic.skeptik.algorithm.compressor.FOSplit.EPFOSplit
 import at.logic.skeptik.expression.{App, Var, i, o}
 import at.logic.skeptik.expression.formula.Atom
 import at.logic.skeptik.judgment.immutable.{SeqSequent => Sequent}
@@ -130,7 +131,7 @@ object ProofGeneratorTests {
       val (proof, vars) = proofGenerationTest(height,Sequent()())//Sequent(Atom("q",List(Var("Z",i))))(Atom("p",List(Var("a",i)))))
       proofsLenghtsSum += proof.size
 
-      val cottonSplit = new FOCottonSplit(vars, timeout)
+      val cottonSplit = new EPFOSplit(vars,timeout)//FOCottonSplit(vars, timeout)
       var rpiCompressedProof   : Proof[Node] = null
       var splitCompressedProof : Proof[Node] = null
       try {

--- a/src/test/scala/at/logic/skeptik/algorithm/FOProofsGenerator/ProofGeneratorTests.scala
+++ b/src/test/scala/at/logic/skeptik/algorithm/FOProofsGenerator/ProofGeneratorTests.scala
@@ -125,8 +125,9 @@ object ProofGeneratorTests {
     var rpiAv     = 0.0
     var splitFail = 0
     var rpiFail   = 0
-    for(i <- 1 to proofN) {
-      val (proof, vars) = proofGenerationTest(height,Sequent()())
+    var c = 0
+    for(h <- 1 to proofN) {
+      val (proof, vars) = proofGenerationTest(height,Sequent()())//Sequent(Atom("q",List(Var("Z",i))))(Atom("p",List(Var("a",i)))))
       proofsLenghtsSum += proof.size
 
       val cottonSplit = new FOCottonSplit(vars, timeout)
@@ -159,24 +160,23 @@ object ProofGeneratorTests {
         rpiProofsLenghtsSum += proof.size
 
       if (countResolutionNodes(proof) > countResolutionNodes(splitCompressedProof)
-        && splitCompressedProof.root.conclusion.ant.isEmpty
-        && splitCompressedProof.root.conclusion.suc.isEmpty
         && countResolutionNodes(splitCompressedProof) > countResolutionNodes(proof) / 2) {
         splN += 1
         splitProofsLenghtsSum += splitCompressedProof.size
         splAv += (countResolutionNodes(splitCompressedProof) * 1.0) / countResolutionNodes(proof)
         println("FOSplit: " + countResolutionNodes(proof) + " -> " + countResolutionNodes(splitCompressedProof))
-      } else if(splitCompressedProof.root.conclusion.ant.nonEmpty || splitCompressedProof.root.conclusion.suc.nonEmpty) {
+      } /*else if (countResolutionNodes(proof) > countResolutionNodes(splitCompressedProof)
+        && countResolutionNodes(splitCompressedProof) <= countResolutionNodes(proof) / 2) {
         splitFail += 1
-        splitProofsLenghtsSum += proof.size
-      } else
+        splitProofsLenghtsSum += splitCompressedProof.size
+      }*/ else
         splitProofsLenghtsSum += proof.size
     }
 
     println("Average proof size: " + (proofsLenghtsSum * 1.0)/proofN)
     println("FOSplit\nReduced: " + splN + " proof(s)\nFailed in : " + splF + " proof(s)\nThe average compression was to " + splAv/splN)
     println("Total compression ratio: " + ((proofsLenghtsSum - splitProofsLenghtsSum)*1.0)/proofsLenghtsSum)
-    println("Number of fails: " + splitFail)
+    println("Number of too artifietial proof(s): " + splitFail)
     println("FORPI\nReduced: " + rpiN + " proof(s)\nFailed in: " + rpiF + " proof(s)\nThe average compression was to " + rpiAv/rpiN)
     println("Total compression ratio: " + ((proofsLenghtsSum - rpiProofsLenghtsSum)*1.0)/proofsLenghtsSum)
     println("Number of fails: " + rpiFail)

--- a/src/test/scala/at/logic/skeptik/algorithm/FOProofsGenerator/ProofGeneratorTests.scala
+++ b/src/test/scala/at/logic/skeptik/algorithm/FOProofsGenerator/ProofGeneratorTests.scala
@@ -22,7 +22,7 @@ object ProofGeneratorTests {
   def main(arfs : Array[String]) : Unit = {
     //testContraction()
     //randomLiteralTest()
-    compressionTests(1000,7,1)
+    compressionTests(1000,7,1000)
     //tests(1000,7,1)
     //f()
   }
@@ -123,6 +123,7 @@ object ProofGeneratorTests {
     var splF      = 0
     var splAv     = 0.0
     var rpiAv     = 0.0
+    var splitFail = 0
     for(i <- 1 to proofN) {
       val (proof, vars) = proofGenerationTest(height,Sequent()())
       proofsLenghtsSum += proof.size
@@ -163,6 +164,7 @@ object ProofGeneratorTests {
         splAv += (countResolutionNodes(splitCompressedProof) * 1.0) / countResolutionNodes(proof)
         println("FOSplit: " + countResolutionNodes(proof) + " -> " + countResolutionNodes(splitCompressedProof))
       } else if(splitCompressedProof.root.conclusion.ant.nonEmpty || splitCompressedProof.root.conclusion.suc.nonEmpty) {
+        splitFail += 1
         splitProofsLenghtsSum += proof.size
       } else
         splitProofsLenghtsSum += proof.size
@@ -171,6 +173,7 @@ object ProofGeneratorTests {
     println("Average proof size: " + (proofsLenghtsSum * 1.0)/proofN)
     println("FOSplit\nReduced: " + splN + " proof(s)\nFailed in : " + splF + " proof(s)\nThe average compression was to " + splAv/splN)
     println("Total compression ratio: " + ((proofsLenghtsSum - splitProofsLenghtsSum)*1.0)/proofsLenghtsSum)
+    println("Number of fails: " + splitFail)
     println("FORPI\nReduced: " + rpiN + " proof(s)\nFailed in: " + rpiF + " proof(s)\nThe average compression was to " + rpiAv/rpiN)
     println("Total compression ratio: " + ((proofsLenghtsSum - rpiProofsLenghtsSum)*1.0)/proofsLenghtsSum)
   }

--- a/src/test/scala/at/logic/skeptik/algorithm/FOProofsGenerator/ProofGeneratorTests.scala
+++ b/src/test/scala/at/logic/skeptik/algorithm/FOProofsGenerator/ProofGeneratorTests.scala
@@ -131,7 +131,7 @@ object ProofGeneratorTests {
       val (proof, vars) = proofGenerationTest(height,Sequent()())//Sequent(Atom("q",List(Var("Z",i))))(Atom("p",List(Var("a",i)))))
       proofsLenghtsSum += proof.size
 
-      val cottonSplit = new EPFOSplit(vars,timeout)//FOCottonSplit(vars, timeout)
+      val cottonSplit = new FOCottonSplit(vars, timeout)//EPFOSplit(vars,timeout)//
       var rpiCompressedProof   : Proof[Node] = null
       var splitCompressedProof : Proof[Node] = null
       try {
@@ -161,8 +161,10 @@ object ProofGeneratorTests {
         rpiProofsLenghtsSum += proof.size
 
       if (countResolutionNodes(proof) > countResolutionNodes(splitCompressedProof)
-        && countResolutionNodes(splitCompressedProof) > countResolutionNodes(proof) / 2) {
+        && countResolutionNodes(splitCompressedProof) > countResolutionNodes(proof) / 20000) {
         splN += 1
+        if(countResolutionNodes(splitCompressedProof) <= countResolutionNodes(proof) / 2)
+          splitFail += 1
         splitProofsLenghtsSum += splitCompressedProof.size
         splAv += (countResolutionNodes(splitCompressedProof) * 1.0) / countResolutionNodes(proof)
         println("FOSplit: " + countResolutionNodes(proof) + " -> " + countResolutionNodes(splitCompressedProof))

--- a/src/test/scala/at/logic/skeptik/algorithm/compressor/FOSplittingExperiment.scala
+++ b/src/test/scala/at/logic/skeptik/algorithm/compressor/FOSplittingExperiment.scala
@@ -10,6 +10,7 @@ import collection.mutable.{HashSet => MSet}
 import java.io.PrintWriter
 
 import at.logic.skeptik.algorithm.compressor.FOSplit.FOCottonSplit
+import at.logic.skeptik.algorithm.compressor.FOSplit.EPFOSplit
 import at.logic.skeptik.algorithm.FOProofsGenerator.{ProofGenerator,ProofToTPTPFile}
 import at.logic.skeptik.expression.{Var, i}
 import at.logic.skeptik.expression.formula.Atom
@@ -105,7 +106,7 @@ object FOSplittingExperiment {
 
       report.println("Proof " + totalCountT + ": " + probY)
       val proofToTest = ProofParserSPASS.read(probY)
-      var variables = ProofParserSPASS.getVars()
+      var variables   = ProofParserSPASS.getVars()
 
       val postParseTime = System.nanoTime
 
@@ -115,8 +116,8 @@ object FOSplittingExperiment {
 
       val startTime = System.nanoTime
 
-      val timeout = 100
-      val cottonSplit = new FOCottonSplit(variables, timeout)
+      val timeout = 1
+      val cottonSplit = new EPFOSplit(variables, timeout)
       try {
         val compressedProof = cottonSplit(proofToTest)
 
@@ -201,9 +202,9 @@ object FOSplittingReview {
       while (true) {
         proof = generator.generateProof()
         vars  = generator.getVariables()
-        val split = new FOCottonSplit(vars, 1)
+        val split = new EPFOSplit(vars, 1)
         val compr = split(proof)
-        if(proof.size < 16
+        /*if(proof.size < 16
           && (compr.root.conclusion.ant.nonEmpty || compr.root.conclusion.suc.nonEmpty)) {
           println(ProofToTPTPFile(proof))
           println()
@@ -211,7 +212,7 @@ object FOSplittingReview {
           println()
           println(compr)
           return
-        }
+        }*/
       }
     } catch {
       case e : Exception =>
@@ -229,23 +230,33 @@ object ProofDebug {
   def main(args : Array[String]) : Unit = {
     val proofTPTP =
       """
-        |cnf(c3,axiom,p5(f1(c3,c11))).
-        |cnf(c4,axiom,p9(c8)).
-        |cnf(c5,axiom,~p9(V6) | p5(V6)).
-        |cnf(c6,plain,p5(c8),inference(sr,[status(thm)],[c4,c5])).
-        |cnf(c9,axiom,~p5(c8) | p8(c11,c3)).
-        |cnf(c10,plain,p8(c11,c3),inference(sr,[status(thm)],[c6,c9])).
-        |cnf(c12,axiom,~p5(f1(V3,V4)) | ~p8(V4,V3) | ~p5(V5)).
-        |cnf(c13,plain,~p5(f1(V3,V4)) | ~p8(V4,V3),inference(sr,[status(thm)],[c6,c12])).
-        |cnf(c14,plain,~p5(f1(c3,c11)),inference(sr,[status(thm)],[c10,c13])).
-        |cnf(c15,plain,$false,inference(sr,[status(thm)],[c3,c14])).
+        |cnf(c0,axiom,p3(V2) | p11(V2,V2) | p4(V4,f3(f1(V4,f2(V5,V4,V6)),V7))).
+        |cnf(c1,axiom,~p4(c10,f3(f1(c10,f2(c12,c10,c5)),c1))).
+        |cnf(c2,plain,p3(V2) | p11(V2,V2),inference(sr,[status(thm)],[c0,c1])).
+        |cnf(c3,axiom,~p11(V2,V2) | p9(V2) | p4(V8,f3(f1(V8,f2(V9,V8,c5)),c1))).
+        |cnf(c4,plain,~p11(V2,V2) | p9(V2),inference(sr,[status(thm)],[c3,c1])).
+        |cnf(c5,plain,p3(V2) | p9(V2),inference(sr,[status(thm)],[c2,c4])).
+        |cnf(c6,axiom,p10(c6) | p9(c12)).
+        |cnf(c7,axiom,~p9(c12)).
+        |cnf(c8,plain,p10(c6),inference(sr,[status(thm)],[c6,c7])).
+        |cnf(c9,axiom,~p9(V3) | ~p10(V3) | p9(c12)).
+        |cnf(c10,plain,~p9(V3) | ~p10(V3),inference(sr,[status(thm)],[c9,c7])).
+        |cnf(c11,plain,~p9(c6),inference(sr,[status(thm)],[c8,c10])).
+        |cnf(c12,plain,p3(c6),inference(sr,[status(thm)],[c5,c11])).
+        |cnf(c13,axiom,p7(c6) | p7(V1)).
+        |cnf(c14,plain,p7(c6),inference(cn,[status(thm)],[c13])).
+        |cnf(c15,axiom,~p7(V0) | p8(V0,V0)).
+        |cnf(c16,axiom,~p3(V0) | ~p8(V0,V0)).
+        |cnf(c17,plain,~p7(V0) | ~p3(V0),inference(sr,[status(thm)],[c15,c16])).
+        |cnf(c18,plain,~p3(c6),inference(sr,[status(thm)],[c14,c17])).
+        |cnf(c19,plain,$false,inference(sr,[status(thm)],[c12,c18])).
       """.stripMargin
     val proof = ProofParserCNFTPTP.extractFromString(proofTPTP)
     val vars  = ProofParserCNFTPTP.getVariables
     ProofParserCNFTPTP.resetVariables()
     println(proof)
     try{
-      val split = new FOCottonSplit(vars, 1)
+      val split = new EPFOSplit(vars, 1)
       println(split(proof))
     } catch {
       case e : Exception =>


### PR DESCRIPTION
Bugs were corrected and an analysis over the heuristics was made.

A variation of the Splitting algorithm was implemented as EPFOSplit, standing for Essentially Propositional First-Order splitting algorithm, in which after selecting a literal for splitting, we split over all occurrences of alpha equivalent literals used as pivots. In this algorithm we kept the heuristic of set inclusion defined for FOSplitting.

A variation regarding strictly propositional literals (i.e. with no variables) will be implemented as future work.
